### PR TITLE
Angus/layout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ If you encounter a problem with the server or documentation, please submit an is
 Still to be implemented:
 - Better error feedback
 - More flexibility with external auth
-- API endpoints for saving user layouts (not currently implemented)
+- Integration with a CARTA frontend npm package

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The CARTA server provides a simple dashboard which authenticates users and allow
 
 ## Dependencies
 
-To allow the server to serve CARTA sessions, you must give it access to an executable CARTA backend, which can be either a compiled executable or a container. You must also build the CARTA frontend, and adjust the server configuration to point to it. You should use the `dev` branch of [`carta-backend`](https://github.com/CARTAvis/carta-backend). and the `angus/database_service` branch of [`carta-frontend`](https://github.com/CARTAvis/carta-frontend).
+To allow the server to serve CARTA sessions, you must give it access to an executable CARTA backend, which can be either a compiled executable or a container. You must also build the CARTA frontend, and adjust the server configuration to point to it. You should use the `dev` branch of [`carta-backend`](https://github.com/CARTAvis/carta-backend). and the `dev` branch of [`carta-frontend`](https://github.com/CARTAvis/carta-frontend).
 
 By default, the server runs on port 8000. It should be run behind a proxy, so that it can be accessed via HTTP and HTTPS. 
 

--- a/config/example_sudoers_conf.stub
+++ b/config/example_sudoers_conf.stub
@@ -1,7 +1,7 @@
 # customise this file to fit your environment using visudo /etc/sudoers.d/carta_server
 
 # carta user can run the carta_backend command as any user in the carta-users group without entering password
-carta ALL=(%carta-users) NOPASSWD: /usr/local/bin/carta_backend
+carta ALL=(%carta-users) NOPASSWD:SETENV: /usr/local/bin/carta_backend
 
 # carta user can run the kill script as any user in the carta-users group without entering password
 carta ALL=(%carta-users) NOPASSWD: /usr/local/bin/carta_kill_script.sh

--- a/config/layout_schema_2.json
+++ b/config/layout_schema_2.json
@@ -1,0 +1,450 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Layout",
+    "description": "Schema for CARTA Layout (Version 2)",
+    "$id": "carta_layout_2",
+    "definitions": {
+        "percentage-value": {
+            "description": "Describes a percentage value from 0 to 100",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+        },
+        "plot-type": {
+            "description": "Describes a plot type",
+            "enum": [
+                "Steps",
+                "Lines",
+                "Points"
+            ]
+        },
+        "line-width": {
+            "description": "Describes a plot line width",
+            "type": "number",
+            "minimum": 0.5,
+            "maximum": 10.0
+        },
+        "point-size": {
+            "description": "Describes a plot point size",
+            "type": "number",
+            "minimum": 0.5,
+            "maximum": 10.0
+        },
+        "opacity": {
+            "description": "Describes an opacity value between zero and one",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+        },
+        "basic-widget": {
+            "description": "Widgets that have no associated settings",
+            "required": [
+                "type",
+                "id"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "const": "component"
+                },
+                "id": {
+                    "type": "string",
+                    "enum": [
+                        "layer-list",
+                        "log",
+                        "animator",
+                        "region-list",
+                        "image-view",
+                        "stats",
+                        "spectral-line-query",
+                        "catalog-overlay"
+                    ]
+                },
+                "width": {
+                    "$ref": "#/definitions/percentage-value"
+                },
+                "height": {
+                    "$ref": "#/definitions/percentage-value"
+                }
+            }
+        },
+        "spectral-profiler": {
+            "description": "Spectral profiler widgets",
+            "required": [
+                "type",
+                "id"
+            ],
+            "properties": {
+                "type": {
+                    "const": "component"
+                },
+                "id": {
+                    "const": "spectral-profiler"
+                },
+                "widgetSettings": {
+                    "properties": {
+                        "coordinate": {
+                            "enum": [
+                                "z",
+                                "Iz",
+                                "Qz",
+                                "Uz",
+                                "Vz"
+                            ]
+                        },
+                        "primaryLineColor": {
+                            "type": "string"
+                        },
+                        "lineWidth": {
+                            "$ref": "#/definitions/line-width"
+                        },
+                        "linePlotPointSize": {
+                            "$ref": "#/definitions/point-size"
+                        },
+                        "meanRmsVisible": {
+                            "type": "boolean"
+                        },
+                        "plotType": {
+                            "$ref": "#/definitions/plot-type"
+                        },
+                        "minXVal": {
+                            "type": "number"
+                        },
+                        "maxXVal": {
+                            "type": "number"
+                        },
+                        "minYVal": {
+                            "type": "number"
+                        },
+                        "maxYVal": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "width": {
+                    "$ref": "#/definitions/percentage-value"
+                },
+                "height": {
+                    "$ref": "#/definitions/percentage-value"
+                }
+            }
+        },
+        "spatial-profiler": {
+            "description": "Spatial profiler widgets",
+            "required": [
+                "type",
+                "id"
+            ],
+            "properties": {
+                "type": {
+                    "const": "component"
+                },
+                "id": {
+                    "const": "spatial-profiler"
+                },
+                "widgetSettings": {
+                    "properties": {
+                        "coordinate": {
+                            "enum": [
+                                "x",
+                                "Ix",
+                                "Qx",
+                                "Ux",
+                                "Vx",
+                                "y",
+                                "Iy",
+                                "Qy",
+                                "Uy",
+                                "Vy"
+                            ],
+                            "default": "x"
+                        },
+                        "primaryLineColor": {
+                            "type": "string"
+                        },
+                        "lineWidth": {
+                            "$ref": "#/definitions/line-width"
+                        },
+                        "linePlotPointSize": {
+                            "$ref": "#/definitions/point-size"
+                        },
+                        "wcsAxisVisible": {
+                            "type": "boolean"
+                        },
+                        "meanRmsVisible": {
+                            "type": "boolean"
+                        },
+                        "plotType": {
+                            "$ref": "#/definitions/plot-type"
+                        },
+                        "minXVal": {
+                            "type": "number"
+                        },
+                        "maxXVal": {
+                            "type": "number"
+                        },
+                        "minYVal": {
+                            "type": "number"
+                        },
+                        "maxYVal": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "width": {
+                    "$ref": "#/definitions/percentage-value"
+                },
+                "height": {
+                    "$ref": "#/definitions/percentage-value"
+                }
+            }
+        },
+        "render-config": {
+            "description": "Render config widgets",
+            "required": [
+                "type",
+                "id"
+            ],
+            "properties": {
+                "type": {
+                    "const": "component"
+                },
+                "id": {
+                    "const": "render-config"
+                },
+                "widgetSettings": {
+                    "properties": {
+                        "primaryLineColor": {
+                            "type": "string"
+                        },
+                        "lineWidth": {
+                            "$ref": "#/definitions/line-width"
+                        },
+                        "linePlotPointSize": {
+                            "$ref": "#/definitions/point-size"
+                        },
+                        "logScaleY": {
+                            "type": "boolean"
+                        },
+                        "markerTextVisible": {
+                            "type": "boolean"
+                        },
+                        "meanRmsVisible": {
+                            "type": "boolean"
+                        },
+                        "plotType": {
+                            "$ref": "#/definitions/plot-type"
+                        },
+                        "minXVal": {
+                            "type": "number"
+                        },
+                        "maxXVal": {
+                            "type": "number"
+                        },
+                        "minYVal": {
+                            "type": "number"
+                        },
+                        "maxYVal": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "width": {
+                    "$ref": "#/definitions/percentage-value"
+                },
+                "height": {
+                    "$ref": "#/definitions/percentage-value"
+                }
+            }
+        },
+        "histogram": {
+            "description": "Histogram widgets",
+            "required": [
+                "type",
+                "id"
+            ],
+            "properties": {
+                "type": {
+                    "const": "component"
+                },
+                "id": {
+                    "const": "histogram"
+                },
+                "widgetSettings": {
+                    "properties": {
+                        "primaryLineColor": {
+                            "type": "string"
+                        },
+                        "lineWidth": {
+                            "$ref": "#/definitions/line-width"
+                        },
+                        "linePlotPointSize": {
+                            "$ref": "#/definitions/point-size"
+                        },
+                        "logScaleY": {
+                            "type": "boolean"
+                        },
+                        "plotType": {
+                            "$ref": "#/definitions/plot-type"
+                        },
+                        "minXVal": {
+                            "type": "number"
+                        },
+                        "maxXVal": {
+                            "type": "number"
+                        },
+                        "minYVal": {
+                            "type": "number"
+                        },
+                        "maxYVal": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "width": {
+                    "$ref": "#/definitions/percentage-value"
+                },
+                "height": {
+                    "$ref": "#/definitions/percentage-value"
+                }
+            }
+        },
+        "stokes": {
+            "description": "Stokes analysis widgets",
+            "required": [
+                "type",
+                "id"
+            ],
+            "properties": {
+                "type": {
+                    "const": "component"
+                },
+                "id": {
+                    "const": "stokes"
+                },
+                "widgetSettings": {
+                    "properties": {
+                        "primaryLineColor": {
+                            "type": "string"
+                        },
+                        "secondaryLineColor": {
+                            "type": "string"
+                        },
+                        "lineWidth": {
+                            "$ref": "#/definitions/line-width"
+                        },
+                        "linePlotPointSize": {
+                            "$ref": "#/definitions/point-size"
+                        },
+                        "plotType": {
+                            "$ref": "#/definitions/plot-type"
+                        },
+                        "colorMap": {
+                            "type": "string"
+                        },
+                        "scatterPlotPointSize": {
+                            "$ref": "#/definitions/point-size"
+                        },
+                        "pointTransparency": {
+                            "$ref": "#/definitions/opacity"
+                        },
+                        "equalAxes": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "width": {
+                    "$ref": "#/definitions/percentage-value"
+                },
+                "height": {
+                    "$ref": "#/definitions/percentage-value"
+                }
+            }
+        },
+        "carta-widget": {
+            "description": "A CARTA widget",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/basic-widget"
+                },
+                {
+                    "$ref": "#/definitions/spectral-profiler"
+                },
+                {
+                    "$ref": "#/definitions/spatial-profiler"
+                },
+                {
+                    "$ref": "#/definitions/render-config"
+                },
+                {
+                    "$ref": "#/definitions/histogram"
+                },
+                {
+                    "$ref": "#/definitions/stokes"
+                }
+            ]
+        },
+        "gl-container": {
+            "description": "A GoldenLayout container",
+            "type": "object",
+            "required": [
+                "type",
+                "content"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "enum": [
+                        "row",
+                        "column",
+                        "stack"
+                    ]
+                },
+                "content": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/gl-container"
+                            },
+                            {
+                                "$ref": "#/definitions/carta-widget"
+                            }
+                        ]
+                    }
+                },
+                "width": {
+                    "$ref": "#/definitions/percentage-value"
+                },
+                "height": {
+                    "$ref": "#/definitions/percentage-value"
+                }
+            }
+        }
+    },
+    "required": [
+        "layoutVersion",
+        "docked",
+        "floating"
+    ],
+    "properties": {
+        "layoutVersion": {
+            "description": "The version of the layout contained",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2
+        },
+        "docked": {
+            "description": "GoldenLayout widget hierarchy",
+            "$ref": "#/definitions/gl-container"
+        },
+        "floating": {
+            "description": "List of floating widgets",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/carta-widget"
+            }
+        }
+    }
+}

--- a/config/preference_schema_1.json
+++ b/config/preference_schema_1.json
@@ -1,13 +1,14 @@
 {
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Preferences",
     "description": "Schema for CARTA Preferences (Version 1)",
+    "$id": "carta_preferences_1",
     "required": [
-        "version",
-        "username"
+        "version"
     ],
     "properties": {
         "version": {
-            "type": "number",
+            "type": "integer",
             "minimum": 1
         },
         "username": {
@@ -64,14 +65,12 @@
             ]
         },
         "wcsMatchingType": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 0,
             "maximum": 3
         },
         "scaling": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 0,
             "maximum": 7
         },
@@ -80,10 +79,8 @@
         },
         "percentile": {
             "type": "number",
-            "maximum": 100,
-            "exclusiveMaximum": true,
-            "minimum": 0,
-            "exclusiveMinimum": true
+            "exclusiveMaximum": 100,
+            "exclusiveMinimum": 0
         },
         "scalingAlpha": {
             "type": "number",
@@ -91,8 +88,7 @@
         },
         "scalingGamma": {
             "type": "number",
-            "minimum": 0,
-            "exclusiveMinimum": true
+            "exclusiveMinimum": 0
         },
         "nanColorHex": {
             "type": "string",
@@ -113,19 +109,16 @@
             ]
         },
         "contourSmoothingMode": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 0,
             "maximum": 2
         },
         "contourSmoothingFactor": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 0
         },
         "contourNumLevels": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 1
         },
         "contourThickness": {
@@ -143,8 +136,7 @@
             "type": "string"
         },
         "astColor": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 0
         },
         "astGridVisible": {
@@ -187,13 +179,11 @@
             "minimum": 0
         },
         "regionDashLength": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 0
         },
         "regionType": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 0,
             "maximum": 6
         },
@@ -205,47 +195,43 @@
             ]
         },
         "imageCompressionQuality": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 4,
             "maximum": 32
         },
         "animationCompressionQuality": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 4,
             "maximum": 32
         },
         "GPUTileCache": {
-            "type": "number",
+            "type": "integer",
             "multipleOf": 128,
             "minimum": 512
         },
         "systemTileCache": {
-            "type": "number",
+            "type": "integer",
             "multipleOf": 128,
             "minimum": 1024
         },
         "contourDecimation": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 1,
             "maximum": 32
         },
         "contourCompressionLevel": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 0,
             "maximum": 19
         },
         "contourChunkSize": {
-            "type": "number",
+            "type": "integer",
             "multipleOf": 25000,
             "minimum": 25000,
             "maximum": 1000000
         },
         "contourControlMapWidth": {
-            "type": "number",
+            "type": "integer",
             "multipleOf": 128,
             "minimum": 128,
             "maximum": 1024
@@ -257,8 +243,7 @@
             "type": "boolean"
         },
         "stopAnimationPlayback": {
-            "type": "number",
-            "multipleOf": 1.0,
+            "type": "integer",
             "minimum": 5,
             "maximum": 30
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carta-node-server",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -34,6 +34,13 @@
         "semver": "^5.5.0",
         "shimmer": "^1.2.0",
         "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "@opencensus/propagation-b3": {
@@ -56,6 +63,11 @@
             "shimmer": "^1.2.0",
             "uuid": "^3.2.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -122,6 +134,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -131,16 +144,9 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.2.tgz",
       "integrity": "sha512-+uWmsejEHfmSjyyM/LkrP0orfE2m5Mx9Xel4tXNeqi1ldK5XMQcDsFkBmLDtuyKUbxj2jGDo0H240fbCRJZo7Q==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/chalk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
-      "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
-      "requires": {
-        "chalk": "*"
       }
     },
     "@types/color-name": {
@@ -152,6 +158,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.7.0.tgz",
       "integrity": "sha512-3LzWUM+3k3XdWOUk/RO+uSjv7YWOatYq2QADJntK1pjkk4DfVP0KrIEPDnXRJxAAGKe0VpIPRmlINLDuCedZWw==",
+      "dev": true,
       "requires": {
         "@types/express": "*"
       }
@@ -160,6 +167,7 @@
       "version": "3.4.33",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
       "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -168,6 +176,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.2.tgz",
       "integrity": "sha512-uwcY8m6SDQqciHsqcKDGbo10GdasYsPCYkH3hVegj9qAah6pX5HivOnOuI3WYmyQMnOATV39zv/Ybs0bC/6iVg==",
+      "dev": true,
       "requires": {
         "@types/express": "*"
       }
@@ -176,6 +185,7 @@
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==",
+      "dev": true,
       "requires": {
         "@types/express": "*"
       }
@@ -184,6 +194,7 @@
       "version": "4.17.7",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.7.tgz",
       "integrity": "sha512-dCOT5lcmV/uC2J9k0rPafATeeyz+99xTt54ReX11/LObZgfzJqZNcW27zGhYyX+9iSEGXGt5qLPwRSvBZcLvtQ==",
+      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -195,6 +206,7 @@
       "version": "4.17.8",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
       "integrity": "sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -205,6 +217,7 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.4.tgz",
       "integrity": "sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -213,6 +226,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
       "integrity": "sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -228,12 +242,14 @@
     "@types/mime": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
-      "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q=="
+      "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==",
+      "dev": true
     },
     "@types/mongodb": {
       "version": "3.5.25",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.5.25.tgz",
       "integrity": "sha512-2H/Owt+pHCl9YmBOYnXc3VdnxejJEjVdH+QCWL5ZAfPehEn3evygKBX3/vKRv7aTwfNbUd0E5vjJdQklH/9a6w==",
+      "dev": true,
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
@@ -242,7 +258,8 @@
     "@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
     },
     "@types/node": {
       "version": "14.0.26",
@@ -252,26 +269,35 @@
     "@types/qs": {
       "version": "6.9.3",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA=="
+      "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA==",
+      "dev": true
     },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
     },
     "@types/serve-static": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
       "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
+      "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
       }
     },
+    "@types/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-xSQfNcvOiE5f9dyd4Kzxbof1aTrLobL278pGLKOZI6esGfZ7ts9Ka16CzIN6Y8hFHE1C7jIBZokULhK1bOgjRw=="
+    },
     "@types/yargs": {
       "version": "15.0.5",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
       "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -279,7 +305,8 @@
     "@types/yargs-parser": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
-      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+      "dev": true
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -349,7 +376,8 @@
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -502,7 +530,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "bunyan": {
       "version": "1.8.12",
@@ -737,7 +766,8 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "doctypes": {
       "version": "1.1.0",
@@ -1531,7 +1561,8 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -2259,6 +2290,7 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -2336,6 +2368,7 @@
       "version": "8.10.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
       "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "dev": true,
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
@@ -2369,7 +2402,8 @@
     "typescript": {
       "version": "3.9.7",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -2404,9 +2438,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
     },
     "vary": {
       "version": "1.1.2",
@@ -2535,7 +2569,8 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "license": "ISC",
     "dependencies": {
         "@pm2/io": "^4.3.5",
+        "@types/uuid": "^8.0.0",
         "ajv": "^6.12.3",
         "body-parser": "^1.19.0",
         "chalk": "^4.1.0",
@@ -34,6 +35,7 @@
         "ms": "^2.1.2",
         "pug": "^3.0.0",
         "userid": "^1.0.0-beta.6",
+        "uuid": "^8.3.0",
         "yargs": "^15.4.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "carta-node-server",
-    "version": "1.0.4",
+    "version": "1.0.4-alpha.0",
     "description": "NodeJS-based server for CARTA",
     "repository": "https://github.com/CARTAvis/carta-node-server",
     "homepage": "http://cartavis.github.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "carta-node-server",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "NodeJS-based server for CARTA",
     "repository": "https://github.com/CARTAvis/carta-node-server",
     "homepage": "http://cartavis.github.io/",


### PR DESCRIPTION
- Adds support for the layout API added in https://github.com/CARTAvis/carta-frontend/pull/1081
- Updated preference schema for consistency with frontend repo
- Validation moved from mongoDB to server code (in order to use consistent schema definitions)
- Additional security feature: auth header injection when proxying websocket connections

(note, sudoers stub has been updated, if upgrading from previous server version, please edit your sudoers file)
