### PR TITLE
renamed package to carta-controller, adjusted readme accordingly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 node_modules/*
 dist/*.js
 dist/*.js.map
-carta-node-server-*.tgz
+carta-controller-*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,4 @@ node_modules/*
 src/*
 dist/*.js.map
 tsconfig.json
-carta-node-server-*.tgz
+carta-controller-*.tgz

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
-# CARTA Server
+# CARTA Controller
 [![carta version](https://img.shields.io/badge/CARTA%20Version-2.0.0--dev.21.02.08-brightgreen)](https://github.com/CARTAvis/carta-backend/releases/tag/v2.0.0-dev.21.02.08)
-[![npm version](http://img.shields.io/npm/v/carta-node-server.svg?style=flat)](https://npmjs.org/package/carta-node-server "View this project on npm")
-![last commit](https://img.shields.io/github/last-commit/CARTAvis/carta-node-server)
-![commit activity](https://img.shields.io/github/commit-activity/m/CARTAvis/carta-node-server)
+[![npm version](http://img.shields.io/npm/v/carta-controller.svg?style=flat)](https://npmjs.org/package/carta-controller "View this project on npm")
+![last commit](https://img.shields.io/github/last-commit/CARTAvis/carta-controller)
+![commit activity](https://img.shields.io/github/commit-activity/m/CARTAvis/carta-controller)
 
 ## Introduction
 
-The CARTA server provides a simple dashboard which authenticates users and allows them to manage their CARTA backend processes. It also serves static frontend code to clients, and dynamically redirects authenticated client connections to the appropriate backend processes. The server can either handle authentication itself, or delegate it to an external OAuth2-based authentication server.
+The CARTA controller provides a simple dashboard which authenticates users and allows them to manage their CARTA backend processes. It also serves static frontend code to clients, and dynamically redirects authenticated client connections to the appropriate backend processes. The controller can either handle authentication itself, or delegate it to an external OAuth2-based authentication server.
 
 ## Dependencies
 
-To allow the server to serve CARTA sessions, you must give it access to an executable CARTA backend, which can be either a compiled executable or a container. If you want to use a non-standard version of the CARTA frontend, you must also build it, and adjust the server configuration to point to it. You should use the `v2.0.0-dev.21.02.08` tag of [`carta-backend`](https://github.com/CARTAvis/carta-backend).
+To allow the controller to serve CARTA sessions, you must give it access to an executable CARTA backend, which can be either a compiled executable or a container. If you want to use a non-standard version of the CARTA frontend, you must also build it, and adjust the controller configuration to point to it. You should use the `v2.0.0-dev.21.02.08` tag of [`carta-backend`](https://github.com/CARTAvis/carta-backend).
 
-By default, the server runs on port 8000. It should be run behind a proxy, so that it can be accessed via HTTP and HTTPS. 
+By default, the controller runs on port 8000. It should be run behind a proxy, so that it can be accessed via HTTP and HTTPS. 
 
-MongoDB is required for storing user preferences, layouts and (in the near future) server metrics. You also need a working [NodeJS LTS](https://github.com/nvm-sh/nvm#long-term-support) installation with NPM. Use `npm install` to install all Node dependencies.
+MongoDB is required for storing user preferences, layouts and (in the near future) controller metrics. You also need a working [NodeJS LTS](https://github.com/nvm-sh/nvm#long-term-support) installation with NPM. Use `npm install` to install all Node dependencies.
 
 ## Installation
 
-You can install the CARTA server from NPM by running `npm install -g carta-node-server` and then running `carta-node-server`.
-You can also install the server from GitHub by cloning this repository, running `npm install` and then `npm run start`.
+You can install the CARTA controller from NPM by running `npm install -g carta-controller` and then running `carta-controller`.
+You can also install the controller from GitHub by cloning this repository, running `npm install` and then `npm run start`.
 
 ## Authentication support
 
-The CARTA server supports three modes for authentication. All three modes use refresh and access tokens, as described in the [OAuth2 Authorization flow](https://tools.ietf.org/html/rfc6749#section-1.3.1), stored in [JWT](https://jwt.io/) format. The modes are:
-- **LDAP-based authentication**: An existing LDAP server is used for user authentication. After the user's username and password configuration are validated by the LDAP server, `carta-node-server` returns a long-lived refresh token, signed with a private key, which can be exchanged by the CARTA dashboard or the CARTA frontend client for a short-lived access token.
+The CARTA controller supports three modes for authentication. All three modes use refresh and access tokens, as described in the [OAuth2 Authorization flow](https://tools.ietf.org/html/rfc6749#section-1.3.1), stored in [JWT](https://jwt.io/) format. The modes are:
+- **LDAP-based authentication**: An existing LDAP server is used for user authentication. After the user's username and password configuration are validated by the LDAP server, `carta-controller` returns a long-lived refresh token, signed with a private key, which can be exchanged by the CARTA dashboard or the CARTA frontend client for a short-lived access token.
 - **Google authentication**: Google's authentication libraries are used for handling authentication. You must create a new web application in the [Google API console](https://console.developers.google.com/apis/credentials). You will then use the  client ID provided by this application in a number of places during the configuration.
 - **External authentication**: This allows users to authenticate with some external OAuth2-based authentication system. This requires a fair amount of configuration, and has not been well-tested. It is assumed that the refresh token passed by the authentication system is stored as an `HttpOnly` cookie.
 
@@ -34,16 +34,16 @@ openssl genrsa -out carta_private.pem 4096
 openssl rsa -in carta_private.pem -outform PEM -pubout -out carta_public.pem
 ```
 
-## Server Configuration
-Server configuration is handled by a configuration file in JSON format, adhering to the [CARTA config schema](config/config_schema.json). Additional details can be found in the auto-generated config documentation in the `docs` folder, or the [example config](config/example_config.json). By default, the server assumes the config file is located at `/etc/carta/config.json`, but you can change this with the `--config` or `-c` command line argument when running the server. 
+## Controller Configuration
+Controller configuration is handled by a configuration file in JSON format, adhering to the [CARTA config schema](config/config_schema.json). Additional details can be found in the auto-generated config documentation in the `docs` folder, or the [example config](config/example_config.json). By default, the controller assumes the config file is located at `/etc/carta/config.json`, but you can change this with the `--config` or `-c` command line argument when running the controller. 
 
-For external authentication systems, you may need to translate a unique ID (such as email or username) from the authenticated user information to the system user. You can do this by providing a [user lookup table](config/usertable.txt.stub), which is watched by the server and reloaded whenever it is updated.
+For external authentication systems, you may need to translate a unique ID (such as email or username) from the authenticated user information to the system user. You can do this by providing a [user lookup table](config/usertable.txt.stub), which is watched by the controller and reloaded whenever it is updated.
 
-You can alter the server's dashboard appearance by adjusting the `dashboard` field in the config file. You can change the banner image and background, and add login instructions or institutional notices.
+You can alter the controller's dashboard appearance by adjusting the `dashboard` field in the config file. You can change the banner image and background, and add login instructions or institutional notices.
 
 ## System Configuration
 
-The user under which the CARTA server is running (assumed to be `carta`) must be given permission to use `sudo` to start `carta_backend` processes as any authenticated user and stop running `carta_backend` processes belonging to authenticated users. We provide a [kill script](scripts/carta_kill_script.sh) which is only able to kill processes matching the name `carta_backend`. This makes it possible to restrict what processes the `carta` user is permitted to kill.
+The user under which the CARTA controller is running (assumed to be `carta`) must be given permission to use `sudo` to start `carta_backend` processes as any authenticated user and stop running `carta_backend` processes belonging to authenticated users. We provide a [kill script](scripts/carta_kill_script.sh) which is only able to kill processes matching the name `carta_backend`. This makes it possible to restrict what processes the `carta` user is permitted to kill.
 
 To provide the `carta` user with these privileges, you must make modifications to the [sudoers configuration](https://www.sudo.ws/man/1.9.0/sudoers.man.html). An [example sudoers config](config/example_sudoers_conf.stub) is provided. This example allows the `carta` user to run `carta_backend` only as users belonging to a specific group (assumed to be `carta-users`), in order to deny access to unauthorized accounts.
 
@@ -53,22 +53,22 @@ We strongly suggest serving over HTTPS and redirecting HTTP traffic to HTTPS, es
 
 You can also use other HTTP servers, such as Apache. Please ensure that they are set up to forward both standard HTTP requests and WebSocket traffic to the correct port.
 
-By default, the server attempts to write log files to the `/var/log/carta` directory. Please ensure that this directory exists and that the `carta` user has write permission.
+By default, the controller attempts to write log files to the `/var/log/carta` directory. Please ensure that this directory exists and that the `carta` user has write permission.
 
-## Running the server
+## Running the controller
 
 - Checkout and build [carta-backend](https://github.com/CARTAvis/carta-backend) using the `v2.0.0-dev.21.02.08` tag (or create the appropriate container). Detailed instructions for Ubuntu 20.04 are available [here](docs/ubuntu_focal_detailed_install.md).
-- Edit the server configuration file at `/etc/carta/config.json`
+- Edit the controller configuration file at `/etc/carta/config.json`
 - Perform system configuration:
     - Ensure `/var/log/carta` exists and is writeable by the appropriate user    
     - Adjust the sudoers configuration
     - Redirect traffic to port 8000
 
-After you have built the backend and edited the server configuration, you can start the server with `npm run start` (if cloning from the git repository) or just running `carta-node-server` (if installing from NPM). You can use a utility such as [forever](https://github.com/foreversd/forever) or [pm2](https://pm2.keymetrics.io/) to keep the server running.
+After you have built the backend and edited the controller configuration, you can start the controller with `npm run start` (if cloning from the git repository) or just running `carta-controller` (if installing from NPM). You can use a utility such as [forever](https://github.com/foreversd/forever) or [pm2](https://pm2.keymetrics.io/) to keep the controller running.
 
 ## Getting help
 
-If you encounter a problem with the server or documentation, please submit an issue in this repo. If you need assistance in configuration or deployment, please contact the [CARTA helpdesk](mailto:carta_helpdesk@asiaa.sinica.edu.tw).
+If you encounter a problem with the controller or documentation, please submit an issue in this repo. If you need assistance in configuration or deployment, please contact the [CARTA helpdesk](mailto:carta_helpdesk@asiaa.sinica.edu.tw).
 
 ## TODO
 

--- a/docs/ubuntu_focal_detailed_install.md
+++ b/docs/ubuntu_focal_detailed_install.md
@@ -1,4 +1,4 @@
-# Detailed instructions for setting up `carta-node-server` on Ubuntu 20.04.1 (Focal Fossa)
+# Detailed instructions for setting up `carta-controller` on Ubuntu 20.04.1 (Focal Fossa)
 
 ## Dependencies:
 ### Install required packages
@@ -109,9 +109,9 @@ source .bashrc
 nvm install --lts
 nvm install-latest-npm
 
-# Install carta-node-server (includes frontend config)
-npm install -g carta-node-server
-cp ${NVM_BIN}/../lib/node_modules/carta-node-server/scripts/carta_kill_script.sh
+# Install carta-controller (includes frontend config)
+npm install -g carta-controller
+cp ${NVM_BIN}/../lib/node_modules/carta-controller/scripts/carta_kill_script.sh
 
 # ensure bin folder is added to path
 source ~/.profile
@@ -124,5 +124,5 @@ nano config.json
 
 # Install PM2 node service
 npm install -g pm2
-pm2 start carta-node-server
+pm2 start carta-controller
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-    "name": "carta-node-server",
-    "version": "2.0.0-dev.21.02.08",
+    "name": "carta-controller",
+    "version": "2.0.0-dev.21.02.09",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-    "name": "carta-node-server",
-    "version": "2.0.0-dev.21.02.08",
+    "name": "carta-controller",
+    "version": "2.0.0-dev.21.02.09",
     "description": "NodeJS-based server for CARTA",
-    "repository": "https://github.com/CARTAvis/carta-node-server",
+    "repository": "https://github.com/CARTAvis/carta-controller",
     "homepage": "http://cartavis.github.io/",
     "main": "dist/index.js",
     "bin": {
-        "carta-node-server": "dist/carta-node-server"
+        "carta-controller": "dist/carta-controller"
     },
     "scripts": {
         "start": "npx ts-node src/index.ts",


### PR DESCRIPTION
Minor PR to adjust nomenclature based on @robsimmonds's suggestion. I've backported this PR to the 1.4 release branch (#39) and will deprecate the NPM [carta-node-server](https://www.npmjs.com/package/carta-node-server) package once these PRs have been approved.