### PR TITLE
Documentation edits: system NPM and PAM authentication (backport)

### DIFF
--- a/config/example_config.json
+++ b/config/example_config.json
@@ -13,7 +13,7 @@
     },
     "serverAddress": "https://my-carta-server.com",
     "processCommand": "/usr/bin/carta_backend",
-    "killCommand": "/usr/local/bin/carta_kill_script.sh",
+    "killCommand": "/usr/local/bin/carta-kill-script",
     "rootFolderTemplate": "/home/{username}",
     "baseFolderTemplate": "/home/{username}",
     "dashboard": {

--- a/config/example_config.json
+++ b/config/example_config.json
@@ -1,14 +1,10 @@
 {
     "$schema": "./config_schema.json",
     "authProviders": {
-        "ldap": {
+        "pam": {
             "publicKeyLocation": "/etc/carta/carta_public.pem",
             "privateKeyLocation": "/etc/carta/carta_private.pem",
-            "issuer": "CARTA",
-            "ldapOptions": {
-                "url": "ldap://ldap.address:port",
-                "searchBase": "dc=example"
-            }
+            "issuer": "my-carta-server.com"
         }
     },
     "database": {

--- a/config/example_sudoers_conf.stub
+++ b/config/example_sudoers_conf.stub
@@ -4,4 +4,4 @@
 carta ALL=(%carta-users) NOPASSWD:SETENV: /usr/bin/carta_backend
 
 # carta user can run the kill script as any user in the carta-users group without entering password
-carta ALL=(%carta-users) NOPASSWD: /usr/local/bin/carta_kill_script.sh
+carta ALL=(%carta-users) NOPASSWD: /usr/local/bin/carta-kill-script

--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -40,7 +40,7 @@ When configured to use PAM or LDAP authentication, the controller signs and vali
     openssl genrsa -out carta_private.pem 4096
     openssl rsa -in carta_private.pem -outform PEM -pubout -out carta_public.pem
 
-PAM may be configured to use the host's local UNIX user authentication, or to communicate with a local or remote LDAP server. If PAM is used for authentication, the ``carta`` user must be given read-only access to ``/etc/shadow``.  This is not required if you use the direct LDAP authentication method.
+PAM may be configured to use the host's local UNIX user authentication, or to communicate with a local or remote LDAP server. If the UNIX module is used for authentication, the ``carta`` user must be given read-only access to ``/etc/shadow``.  This is not required if you use PAM's LDAP module or the direct LDAP authentication method.
 
 .. _config-nginx:
 

--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -32,14 +32,16 @@ To provide the ``carta`` user with these privileges, you must make modifications
 Authentication
 ~~~~~~~~~~~~~~
 
-When configured to use LDAP authentication, the controller signs and validates refresh and access tokens with SSL keys. You can generate a private/public key pair in PEM format using ``openssl``:
+When configured to use PAM or LDAP authentication, the controller signs and validates refresh and access tokens with SSL keys. You can generate a private/public key pair in PEM format using ``openssl``:
 
 .. code-block:: shell
 
     cd /etc/carta
     openssl genrsa -out carta_private.pem 4096
     openssl rsa -in carta_private.pem -outform PEM -pubout -out carta_public.pem
-    
+
+PAM may be configured to use the host's local UNIX user authentication, or to communicate with an LDAP server. If PAM is used for authentication, the ``carta`` user must be given read-only access to ``/etc/shadow``.  This is not required if you use the direct LDAP authentication method.
+
 .. _config-nginx:
 
 Nginx
@@ -74,7 +76,7 @@ Controller configuration is handled by a configuration file in JSON format, adhe
 
 By default, the controller assumes the config file is located at ``/etc/carta/config.json``, but you can change this with the ``--config`` or ``-c`` command line argument when running the controller.
 
-The controller automatically executes the backend with the ``--no_http`` flag, to suppress the backend's built-in HTTP server. If the ``logFileTemplate`` configuration option is set, ``--no_log`` is also used to suppress user-level logs. ``--port`` is used to override the default port. ``--top_level_folder`` and a positional argument are used to set the top-level and starting data directories for the user, as specified in the ``rootFolderTemplate`` and ``baseFolderTemplate`` options, respectively. Additional backend flags may be specified with ``additionalArgs``.
+The controller automatically executes the backend with the ``-port`` flag to override the default port. ``-root`` and ``-base`` are used to set the top-level and starting data directories for the user, as specified in the ``rootFolderTemplate`` and ``baseFolderTemplate`` options, respectively. Additional backend flags may be specified with ``additionalArgs``.
 
 If you use an external :ref:`authentication<authentication>` system, you may need to translate a unique ID (such as email or username) from the authenticated external user information to an internal system user. You can do this by providing a `user lookup table <_static/config/usertable.txt.stub>`_, which is watched by the controller and reloaded whenever it is updated:
 

--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -40,7 +40,7 @@ When configured to use PAM or LDAP authentication, the controller signs and vali
     openssl genrsa -out carta_private.pem 4096
     openssl rsa -in carta_private.pem -outform PEM -pubout -out carta_public.pem
 
-PAM may be configured to use the host's local UNIX user authentication, or to communicate with an LDAP server. If PAM is used for authentication, the ``carta`` user must be given read-only access to ``/etc/shadow``.  This is not required if you use the direct LDAP authentication method.
+PAM may be configured to use the host's local UNIX user authentication, or to communicate with a local or remote LDAP server. If PAM is used for authentication, the ``carta`` user must be given read-only access to ``/etc/shadow``.  This is not required if you use the direct LDAP authentication method.
 
 .. _config-nginx:
 

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -30,8 +30,6 @@ Installing the controller
 
 You can install the release version of the CARTA controller from NPM by running ``npm install -g carta-controller``, or from GitHub by cloning the `controller repository <https://github.com/CARTAvis/carta-controller/>`_, checking out the ``release/1.4`` branch, and running ``npm install``.
 
-Specific authentication methods may have additional system dependencies. For example, the default PAM authentication method requires ``libpam0g-dev`` on Ubuntu.
-
 .. _run_controller:
 
 Running the controller

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -30,6 +30,8 @@ Installing the controller
 
 You can install the release version of the CARTA controller from NPM by running ``npm install -g carta-controller``, or from GitHub by cloning the `controller repository <https://github.com/CARTAvis/carta-controller/>`_, checking out the ``release/1.4`` branch, and running ``npm install``.
 
+Specific authentication methods may have additional system dependencies. For example, the default PAM authentication method requires ``libpam0g-dev`` on Ubuntu.
+
 .. _run_controller:
 
 Running the controller

--- a/docs/src/introduction.rst
+++ b/docs/src/introduction.rst
@@ -23,9 +23,10 @@ You also need a working `NodeJS LTS <https://github.com/nvm-sh/nvm#long-term-sup
 Authentication support
 ----------------------
 
-The CARTA controller supports three modes for authentication. All three modes use refresh and access tokens, as described in the `OAuth2 Authorization flow <https://tools.ietf.org/html/rfc6749#section-1.3.1>`_, stored in `JWT <https://jwt.io/>`_ format. The modes are:
+The CARTA controller supports four modes for authentication. All four modes use refresh and access tokens, as described in the `OAuth2 Authorization flow <https://tools.ietf.org/html/rfc6749#section-1.3.1>`_, stored in `JWT <https://jwt.io/>`_ format. The modes are:
 
-* **LDAP-based authentication**: An existing LDAP server is used for user authentication. After the user's username and password configuration are validated by the LDAP server, ``carta-controller`` returns a long-lived refresh token, signed with a private key, which can be exchanged by the CARTA dashboard or the CARTA frontend client for a short-lived access token.
+* **PAM authentication**: The PAM interface of the host system is used for user authentication. After the user's username and password configuration are validated by PAM, ``carta-controller`` returns a long-lived refresh token, signed with a private key, which can be exchanged by the CARTA dashboard or the CARTA frontend client for a short-lived access token.
+* **LDAP authentication**: As above, but an LDAP server is used directly for user authentication.
 * **Google authentication**: Google's authentication libraries are used for handling authentication. You must create a new web application in the `Google API console <https://console.developers.google.com/apis/credentials>`_. You will then use the  client ID provided by this application in a number of places during the configuration.
 * **External authentication**: This allows users to authenticate with some external OAuth2-based authentication system. This requires a fair amount of configuration, and has not been well-tested. It is assumed that the refresh token passed by the authentication system is stored as an ``HttpOnly`` cookie.
 

--- a/docs/src/ubuntu_focal_instructions.rst
+++ b/docs/src/ubuntu_focal_instructions.rst
@@ -29,7 +29,7 @@ Ensure that all users who should have access to CARTA belong to a group that ide
 .. code-block:: shell
 
     # create a 'carta' user to run the controller
-    sudo adduser --disabled-login --gecos "" carta
+    sudo adduser --system --no-create-home --shell=/bin/bash --group carta
 
     # log directory owned by carta
     sudo mkdir -p /var/log/carta

--- a/docs/src/ubuntu_focal_instructions.rst
+++ b/docs/src/ubuntu_focal_instructions.rst
@@ -19,17 +19,20 @@ Install the CARTA backend and other required packages
     sudo apt-get install carta-backend
     
     # Install additional packages
-    sudo apt-get install nginx g++ mongodb make nodejs npm
+    sudo apt-get install nginx g++ mongodb make nodejs npm libpam0g-dev
 
 Set up directories and permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Ensure that all users who should have access to CARTA belong to a group that identifies them (assumed here to be called ``carta-users``). Also ensure that LDAP has been set up correctly.
+Ensure that all users who should have access to CARTA belong to a group that identifies them (assumed here to be called ``carta-users``).
 
 .. code-block:: shell
 
     # create a 'carta' user to run the controller
     sudo adduser --system --no-create-home --shell=/bin/bash --group carta
+    
+    # add 'carta' user to the shadow group (required for PAM authentication)
+    sudo usermod -a -G shadow carta
 
     # log directory owned by carta
     sudo mkdir -p /var/log/carta

--- a/docs/src/ubuntu_focal_instructions.rst
+++ b/docs/src/ubuntu_focal_instructions.rst
@@ -19,7 +19,7 @@ Install the CARTA backend and other required packages
     sudo apt-get install carta-backend
     
     # Install additional packages
-    sudo apt-get install nginx g++ mongodb make nodejs npm libpam0g-dev
+    sudo apt-get install nginx g++ mongodb make nodejs npm
 
 Set up directories and permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -31,7 +31,7 @@ Ensure that all users who should have access to CARTA belong to a group that ide
     # create a 'carta' user to run the controller
     sudo adduser --system --no-create-home --shell=/bin/bash --group carta
     
-    # add 'carta' user to the shadow group (required for PAM authentication)
+    # add 'carta' user to the shadow group (only required for PAM UNIX authentication)
     sudo usermod -a -G shadow carta
 
     # log directory owned by carta

--- a/docs/src/ubuntu_focal_instructions.rst
+++ b/docs/src/ubuntu_focal_instructions.rst
@@ -3,6 +3,10 @@
 Step-by-step instructions for Ubuntu 20.04.2 (Focal Fossa)
 ==========================================================
 
+.. note::
+
+    These instructions can be used almost unchanged on Ubuntu 18.04 (Bionic Badger). We note differences where they occur.
+
 Dependencies
 ------------
 
@@ -57,10 +61,14 @@ A :ref:`sample configuration file<example_nginx>` is provided in the configurati
 Install CARTA controller
 ------------------------
 
+.. note::
+
+    On Ubuntu Bionic, do not pass the ``--unsafe-perm`` flag to ``npm``. This is also unnecessary if you use a custom local installation of ``npm`` with a version of at least 7.0.
+
 .. code-block:: shell
 
     # Install carta-controller (includes frontend config)
-    sudo npm install -g carta-controller
+    sudo npm install -g --unsafe-perm carta-controller
     
     # Install PM2 node service
     sudo npm install -g pm2

--- a/docs/src/ubuntu_focal_instructions.rst
+++ b/docs/src/ubuntu_focal_instructions.rst
@@ -19,7 +19,7 @@ Install the CARTA backend and other required packages
     sudo apt-get install carta-backend
     
     # Install additional packages
-    sudo apt-get install nginx curl g++ mongodb make
+    sudo apt-get install nginx g++ mongodb make nodejs npm
 
 Set up directories and permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -56,24 +56,13 @@ Install CARTA controller
 
 .. code-block:: shell
 
-    # Most of these commands should be executed as the carta user
-    sudo su - carta
-
-    # Install NVM and NPM
-    cd ~
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
-    source .bashrc
-    nvm install --lts
-    nvm install-latest-npm
-
     # Install carta-controller (includes frontend config)
-    npm install -g carta-controller
+    sudo npm install -g carta-controller
     
-    # For security reasons, copy the kill script to a system bin directory
-    cp ${NVM_BIN}/../lib/node_modules/carta-controller/scripts/carta_kill_script.sh ~
-    exit
-    sudo mv /home/carta/carta_kill_script.sh /usr/local/bin/
-    sudo chown root: /usr/local/bin/carta_kill_script.sh
+    # Install PM2 node service
+    sudo npm install -g pm2
+
+    # Switch to carta user
     sudo su - carta
     
     # Generate private/public keys
@@ -93,8 +82,6 @@ This should be executed as the ``carta`` user.
 
 .. code-block:: shell
 
-    # Install PM2 node service
-    npm install -g pm2
     pm2 start carta-controller
 
 Create pm2 startup script

--- a/docs/src/ubuntu_focal_instructions.rst
+++ b/docs/src/ubuntu_focal_instructions.rst
@@ -43,7 +43,7 @@ Ensure that all users who should have access to CARTA belong to a group that ide
     sudo chown carta: /etc/carta
 
     # edit sudoers file to allow passwordless sudo execution of 
-    # /usr/local/bin/carta_kill_script.sh and /usr/bin/carta_backend
+    # /usr/local/bin/carta-kill-script and /usr/bin/carta_backend
     # by the carta user  
     sudo visudo -f /etc/sudoers.d/carta_controller
     


### PR DESCRIPTION
This should not be merged until the node package installs the kill script in /usr/local bin. We should ideally also retest this to make sure that e.g. curl is not a secret dependency.