### PR TITLE
allow jsonc (json with comments) in config file

### DIFF
--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -66,7 +66,7 @@ By default, the controller attempts to write log files to the ``/var/log/carta``
 Controller Configuration
 ------------------------
 
-Controller configuration is handled by a configuration file in JSON format, adhering to the :ref:`CARTA configuration schema<schema>`. An `example configuration file <_static/config/example_config.json>`_ is provided:
+Controller configuration is handled by a configuration file in JSONC (JSON with JavaScript style comments) format, adhering to the :ref:`CARTA configuration schema<schema>`. An `example configuration file <_static/config/example_config.json>`_ is provided:
 
 .. literalinclude:: _static/config/example_config.json
    :language: json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "carta-controller",
-    "version": "2.0.0-dev.21.03.29",
+    "version": "2.0.0-dev.21.03.30",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -857,14 +857,6 @@
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
-        "error-ex": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "requires": {
-                "is-arrayish": "^0.2.1"
-            }
-        },
         "es5-ext": {
             "version": "0.10.53",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
@@ -1073,11 +1065,6 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-        },
-        "fast-safe-stringify": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
         },
         "fast-text-encoding": {
             "version": "1.0.3",
@@ -1322,11 +1309,6 @@
                 "node-forge": "^0.10.0"
             }
         },
-        "graceful-fs": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
-        },
         "gtoken": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.5.tgz",
@@ -1461,11 +1443,6 @@
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         },
-        "is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-        },
         "is-expression": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
@@ -1542,28 +1519,15 @@
                 "bignumber.js": "^9.0.0"
             }
         },
-        "json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
-        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
-        "jsonc": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/jsonc/-/jsonc-2.0.0.tgz",
-            "integrity": "sha512-B281bLCT2TRMQa+AQUQY5AGcqSOXBOKaYGP4wDzoA/+QswUfN8sODektbPEs9Baq7LGKun5jQbNFpzwGuVYKhw==",
-            "requires": {
-                "fast-safe-stringify": "^2.0.6",
-                "graceful-fs": "^4.1.15",
-                "mkdirp": "^0.5.1",
-                "parse-json": "^4.0.0",
-                "strip-bom": "^4.0.0",
-                "strip-json-comments": "^3.0.1"
-            }
+        "jsonc-parser": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+            "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
         },
         "jsonwebtoken": {
             "version": "8.5.1",
@@ -1809,19 +1773,6 @@
                 "mime-db": "1.44.0"
             }
         },
-        "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
-        "mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "requires": {
-                "minimist": "^1.2.5"
-            }
-        },
         "mnemonist": {
             "version": "0.38.1",
             "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.1.tgz",
@@ -2004,15 +1955,6 @@
                 "ip": "^1.1.5",
                 "netmask": "^1.0.6",
                 "thunkify": "^2.1.2"
-            }
-        },
-        "parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-            "requires": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
             }
         },
         "parseurl": {
@@ -2497,16 +2439,6 @@
             "requires": {
                 "ansi-regex": "^5.0.0"
             }
-        },
-        "strip-bom": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
-        },
-        "strip-json-comments": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
         },
         "supports-color": {
             "version": "7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -857,6 +857,14 @@
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
         "es5-ext": {
             "version": "0.10.53",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
@@ -1065,6 +1073,11 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+        },
+        "fast-safe-stringify": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
         },
         "fast-text-encoding": {
             "version": "1.0.3",
@@ -1309,6 +1322,11 @@
                 "node-forge": "^0.10.0"
             }
         },
+        "graceful-fs": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+        },
         "gtoken": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.5.tgz",
@@ -1443,6 +1461,11 @@
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+        },
         "is-expression": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
@@ -1519,10 +1542,28 @@
                 "bignumber.js": "^9.0.0"
             }
         },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "jsonc": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/jsonc/-/jsonc-2.0.0.tgz",
+            "integrity": "sha512-B281bLCT2TRMQa+AQUQY5AGcqSOXBOKaYGP4wDzoA/+QswUfN8sODektbPEs9Baq7LGKun5jQbNFpzwGuVYKhw==",
+            "requires": {
+                "fast-safe-stringify": "^2.0.6",
+                "graceful-fs": "^4.1.15",
+                "mkdirp": "^0.5.1",
+                "parse-json": "^4.0.0",
+                "strip-bom": "^4.0.0",
+                "strip-json-comments": "^3.0.1"
+            }
         },
         "jsonwebtoken": {
             "version": "8.5.1",
@@ -1768,6 +1809,19 @@
                 "mime-db": "1.44.0"
             }
         },
+        "minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "mkdirp": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "requires": {
+                "minimist": "^1.2.5"
+            }
+        },
         "mnemonist": {
             "version": "0.38.1",
             "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.1.tgz",
@@ -1950,6 +2004,15 @@
                 "ip": "^1.1.5",
                 "netmask": "^1.0.6",
                 "thunkify": "^2.1.2"
+            }
+        },
+        "parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
             }
         },
         "parseurl": {
@@ -2434,6 +2497,16 @@
             "requires": {
                 "ansi-regex": "^5.0.0"
             }
+        },
+        "strip-bom": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+        },
+        "strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
         },
         "supports-color": {
             "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "google-auth-library": "^6.1.3",
         "hjson": "^3.2.1",
         "http-proxy": "^1.18.1",
-        "jsonc": "^2.0.0",
+        "jsonc-parser": "^2.0.0",
         "jsonwebtoken": "^8.5.1",
         "ldapauth-fork": "^5.0.1",
         "log-symbols": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "google-auth-library": "^6.1.3",
         "hjson": "^3.2.1",
         "http-proxy": "^1.18.1",
+        "jsonc": "^2.0.0",
         "jsonwebtoken": "^8.5.1",
         "ldapauth-fork": "^5.0.1",
         "log-symbols": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "carta-controller",
-    "version": "2.0.0-dev.21.03.29",
+    "version": "2.0.0-dev.21.03.30",
     "description": "NodeJS-based controller for CARTA",
     "repository": "https://github.com/CARTAvis/carta-controller",
     "homepage": "http://cartavis.github.io/",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 import * as yargs from "yargs";
 import * as Ajv from "ajv";
 import * as url from "url";
+import * as fs from "fs";
+import {jsonc} from "jsonc";
 import {CartaCommandLineOptions, CartaRuntimeConfig, CartaServerConfig} from "./types";
 
 const argv = yargs.options({
@@ -27,7 +29,8 @@ let serverConfig: CartaServerConfig;
 
 try {
     console.log(`Checking config file ${argv.config}`);
-    serverConfig = require(argv.config);
+    const jsonString = fs.readFileSync(argv.config).toString();
+    serverConfig = jsonc.parse(jsonString);
     const isValid = validateConfig(serverConfig);
     if (!isValid) {
         console.error(validateConfig.errors);

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import * as yargs from "yargs";
 import * as Ajv from "ajv";
 import * as url from "url";
 import * as fs from "fs";
-import {jsonc} from "jsonc";
+import {parse} from "jsonc-parser";
 import {CartaCommandLineOptions, CartaRuntimeConfig, CartaServerConfig} from "./types";
 
 const argv = yargs.options({
@@ -30,7 +30,7 @@ let serverConfig: CartaServerConfig;
 try {
     console.log(`Checking config file ${argv.config}`);
     const jsonString = fs.readFileSync(argv.config).toString();
-    serverConfig = jsonc.parse(jsonString);
+    serverConfig = parse(jsonString);
     const isValid = validateConfig(serverConfig);
     if (!isValid) {
         console.error(validateConfig.errors);


### PR DESCRIPTION
This allows us to ignore all `//` and `/* */` comments in the config file. Uses the same jsonc parser that VS code and the new Windows Terminal use. 