### PR TITLE
switch to nodesource repo for LTS NodeJS version in focal instructions

### DIFF
--- a/docs/src/introduction.rst
+++ b/docs/src/introduction.rst
@@ -16,7 +16,7 @@ By default, the controller runs on port 8000. It should be run behind a proxy, s
 
 MongoDB is required for storing user preferences, layouts and (in the near future) controller metrics.
 
-You also need a working `NodeJS LTS <https://github.com/nvm-sh/nvm#long-term-support>`_ installation with NPM. Use ``npm install`` to install all Node dependencies.
+You also need a working `NodeJS LTS <https://nodejs.org/en/about/releases/>`_ installation with NPM. Use ``npm install`` to install all Node dependencies.
 
 .. _authentication:
 

--- a/docs/src/ubuntu_focal_instructions.rst
+++ b/docs/src/ubuntu_focal_instructions.rst
@@ -23,7 +23,7 @@ Install the CARTA backend and other required packages
     sudo apt-get install carta-backend-beta
     
     # Install additional packages
-    sudo apt-get install nginx g++ mongodb make nodejs npm
+    sudo apt-get install nginx g++ mongodb make curl
 
 Set up directories and permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -62,10 +62,13 @@ Install CARTA controller
 ------------------------
 
 .. note::
-
-    On Ubuntu Bionic, do not pass the ``--unsafe-perm`` flag to ``npm``. This is also unnecessary if you use a custom local installation of ``npm`` with a version of at least 7.0.
-
+	Currently supported versions of NodeJS are v12, v14 and v16. In the example below we install the latest LTS version of NodeJS from the NodeSource repo.
 .. code-block:: shell
+	# Install the latest NodeJS LTS repo
+	curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+
+	# Install NodeJS, NPM and tools required to compile native addons
+	sudo apt-get install -y nodejs build-essential
 
     # Install carta-controller (includes frontend config)
     sudo npm install -g --unsafe-perm carta-controller@dev

--- a/docs/src/ubuntu_focal_instructions.rst
+++ b/docs/src/ubuntu_focal_instructions.rst
@@ -62,13 +62,14 @@ Install CARTA controller
 ------------------------
 
 .. note::
-	Currently supported versions of NodeJS are v12, v14 and v16. In the example below we install the latest LTS version of NodeJS from the NodeSource repo.
-.. code-block:: shell
-	# Install the latest NodeJS LTS repo
-	curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+    Currently supported versions of NodeJS are v12, v14 and v16. In the example below we install the latest LTS version of NodeJS from the NodeSource repo. Do not pass the ``--unsafe-perm`` flag to ``npm`` if using a local install.
 
-	# Install NodeJS, NPM and tools required to compile native addons
-	sudo apt-get install -y nodejs build-essential
+.. code-block:: shell
+    # Install the latest NodeJS LTS repo
+    curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+
+    # Install NodeJS, NPM and tools required to compile native addons
+    sudo apt-get install -y nodejs build-essential
 
     # Install carta-controller (includes frontend config)
     sudo npm install -g --unsafe-perm carta-controller@dev

--- a/docs/src/ubuntu_focal_instructions.rst
+++ b/docs/src/ubuntu_focal_instructions.rst
@@ -62,9 +62,11 @@ Install CARTA controller
 ------------------------
 
 .. note::
+
     Currently supported versions of NodeJS are v12, v14 and v16. In the example below we install the latest LTS version of NodeJS from the NodeSource repo. Do not pass the ``--unsafe-perm`` flag to ``npm`` if using a local install.
 
 .. code-block:: shell
+
     # Install the latest NodeJS LTS repo
     curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
 


### PR DESCRIPTION
Will be backported to `release/2.0`