### PR TITLE
Switch to the beta tag; describe this version of the controller as beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CARTA Controller
 
 [![carta version](https://img.shields.io/badge/CARTA%20Version-3.0.0--beta.1c-brightgreen)](https://github.com/CARTAvis/carta-backend/releases/tag/v3.0.0-beta.1c)
-[![npm version](https://img.shields.io/npm/v/carta-controller/dev.svg?style=flat)](https://npmjs.org/package/carta-controller "View this project on npm")
+[![npm version](https://img.shields.io/npm/v/carta-controller/beta.svg?style=flat)](https://npmjs.org/package/carta-controller "View this project on npm")
 ![last commit](https://img.shields.io/github/last-commit/CARTAvis/carta-controller)
 ![commit activity](https://img.shields.io/github/commit-activity/m/CARTAvis/carta-controller)
 

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -8,7 +8,7 @@ Installation
 Installing the backend
 ----------------------
 
-We provide `binary Debian packages <https://launchpad.net/~cartavis-team/+archive/ubuntu/carta>`_ of the latest development and release versions of the CARTA backend for Ubuntu 20.04 (Focal Fossa) and Ubuntu 18.04 (Bionic Beaver). You can install the development version with all dependencies by adding our PPA to your system and running ``apt-get install carta-backend-beta``. Please refer to our :ref:`Ubuntu Focal instructions<focal_instructions>` for more details.
+We provide `binary Debian packages <https://launchpad.net/~cartavis-team/+archive/ubuntu/carta>`_ of the latest beta and release versions of the CARTA backend for Ubuntu 20.04 (Focal Fossa) and Ubuntu 18.04 (Bionic Beaver). You can install the beta version with all dependencies by adding our PPA to your system and running ``apt-get install carta-backend-beta``. Please refer to our :ref:`Ubuntu Focal instructions<focal_instructions>` for more details.
 
 .. note::
 
@@ -28,7 +28,7 @@ If you install the controller from NPM, the corresponding packaged version of th
 Installing the controller
 -------------------------
 
-You can install the development version of the CARTA controller from NPM by running ``npm install -g carta-controller@dev``, or from GitHub by cloning the `controller repository <https://github.com/CARTAvis/carta-controller/>`_ and running ``npm install``.
+You can install the beta version of the CARTA controller from NPM by running ``npm install -g carta-controller@beta``, or from GitHub by cloning the `controller repository <https://github.com/CARTAvis/carta-controller/>`_ and running ``npm install``.
 
 .. _run_controller:
 

--- a/docs/src/ubuntu_focal_instructions.rst
+++ b/docs/src/ubuntu_focal_instructions.rst
@@ -19,7 +19,7 @@ Install the CARTA backend and other required packages
     sudo add-apt-repository ppa:cartavis-team/carta
     sudo apt-get update
 
-    # Install the development backend package with all dependencies
+    # Install the beta backend package with all dependencies
     sudo apt-get install carta-backend-beta
     
     # Install additional packages
@@ -74,7 +74,7 @@ Install CARTA controller
     sudo apt-get install -y nodejs build-essential
 
     # Install carta-controller (includes frontend config)
-    sudo npm install -g --unsafe-perm carta-controller@dev
+    sudo npm install -g --unsafe-perm carta-controller@beta
     
     # Install PM2 node service
     sudo npm install -g pm2


### PR DESCRIPTION
What it says on the tin. We're still using the `dev` branch for this (perhaps we should reevaluate this decision at some point).