### PR TITLE
updating centos8 instructions

### DIFF
--- a/docs/src/centos8_instructions.rst
+++ b/docs/src/centos8_instructions.rst
@@ -65,7 +65,7 @@ The easiest way to install the CARTA controller is using ``npm``.
 .. code-block:: shell
 
     sudo dnf install -y python3 make gcc-c++
-    sudo npm install -g --unsafe-perm carta-controller@beta
+    sudo npm install -g --unsafe-perm carta-controller
 
 .. note::
 
@@ -92,11 +92,10 @@ The easiest way may be to install the CARTA backend is from our cartavis RPM rep
 .. code-block:: shell
 
     # Install the CARTA backend
-    sudo curl https://packages.cartavis.org/cartavis-el8.repo --output /etc/yum.repos.d/cartavis.repo
-    sudo dnf -y install 'dnf-command(config-manager)'
+    sudo dnf -y install 'dnf-command(copr)'
+    sudo dnf -y copr enable cartavis/carta
     sudo dnf -y install epel-release
-    sudo dnf -y config-manager --set-enabled powertools
-    sudo dnf -y install carta-backend-beta
+    sudo dnf -y install carta-backend
 
     # Check that the backend can run and matches the major version number of the controller
     /usr/bin/carta_backend --version

--- a/docs/src/centos8_instructions.rst
+++ b/docs/src/centos8_instructions.rst
@@ -65,7 +65,7 @@ The easiest way to install the CARTA controller is using ``npm``.
 .. code-block:: shell
 
     sudo dnf install -y python3 make gcc-c++
-    sudo npm install -g --unsafe-perm carta-controller
+    sudo npm install -g --unsafe-perm carta-controller@beta
 
 .. note::
 
@@ -95,7 +95,7 @@ The easiest way may be to install the CARTA backend is from our cartavis RPM rep
     sudo dnf -y install 'dnf-command(copr)'
     sudo dnf -y copr enable cartavis/carta
     sudo dnf -y install epel-release
-    sudo dnf -y install carta-backend
+    sudo dnf -y install carta-backend-beta
 
     # Check that the backend can run and matches the major version number of the controller
     /usr/bin/carta_backend --version


### PR DESCRIPTION
I am sorry for forgetting to update the carta-controller instructions after we changed the RPM signing key and switched to use a universal repo file.

I have just updated the centos8 step-by-step instruction page now, this time with instructions to install the carta-backend from our new Copr repo.

I have also updated it to mention the full release and not the beta:
`carta-controller@beta > carta-controller`
`carta-backend-beta > carta-backend`
Perhaps you would wish to do the same for the Ubuntu 20.04 step-by-step? (although I know the Debian beta packages are up-to-date with the current release).