### PR TITLE
Load controller version dynamically from package.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ if (testUser) {
         }
     });
 
+    const packageJson = require(path.join(__dirname, "../package.json"));
     app.get("/dashboard", (req, res) => {
         res.render("templated", {
             googleClientId: ServerConfig.authProviders.google?.clientId,
@@ -93,7 +94,8 @@ if (testUser) {
             bannerImage: bannerDataUri,
             infoText: ServerConfig.dashboard?.infoText,
             loginText: ServerConfig.dashboard?.loginText,
-            footerText: ServerConfig.dashboard?.footerText
+            footerText: ServerConfig.dashboard?.footerText,
+            controllerVersion: packageJson.version
         });
     });
 

--- a/views/templated.pug
+++ b/views/templated.pug
@@ -25,7 +25,7 @@ html
                     .spacer
                     img(src="dashboard/images/carta_logo.svg" alt="carta_logo")
                     .titletext
-                        | CARTA 3.0.0-beta.3
+                        | CARTA #{controllerVersion}
                         br
                         span(style="font-size: 13px; font-weight: lighter") Cube Analysis and Rendering Tool for Astronomy
                         br


### PR DESCRIPTION
The version displayed on the dashboard was previously hardcoded in the template.  This change instead loads it dynamically from the `package.json`.

(The controller, frontend, and backend are separately versioned, but in generally those deploying the controller would be unlikely to load custom versions so I think that it's reasonable to only show the controller version here.