### PR TITLE
ajm/update for copr on 3.0

### DIFF
--- a/docs/src/centos8_instructions.rst
+++ b/docs/src/centos8_instructions.rst
@@ -87,15 +87,14 @@ The easiest way to install the CARTA controller is using ``npm``.
 4. Install the CARTA backend
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The easiest way may be to install the CARTA backend is from our cartavis RPM repository.
+The easiest way is to install the CARTA backend from our `cartavis/carta Copr <https://copr.fedorainfracloud.org/coprs/cartavis/carta/>`_ repository.
 
 .. code-block:: shell
 
     # Install the CARTA backend
-    sudo curl https://packages.cartavis.org/cartavis-el8.repo --output /etc/yum.repos.d/cartavis.repo
-    sudo dnf -y install 'dnf-command(config-manager)'
+    sudo dnf -y install 'dnf-command(copr)'
+    sudo dnf -y copr enable cartavis/carta
     sudo dnf -y install epel-release
-    sudo dnf -y config-manager --set-enabled powertools
     sudo dnf -y install carta-backend
 
     # Check that the backend can run and matches the major version number of the controller


### PR DESCRIPTION
In this update to the `release/3.0` branch, I propose we only make the modification to use the cartavis/carta Copr repository instead of packages.cartavis.org and not change the instances of CentOS8 to AlmaLinux8, if that is OK with you?

I figure we should keep changes to minimal here and we can make the CentOS/AlmaLinux change in the upcoming`release/4.0` branch in August. 

The reason why I am not waiting for `release/4.0` to remove mention of the "packages.cartavis.org" repo, is because "packages.cartavis.org" is long overdue to be decommissioned and so I want to remove it from all current documentation as soon as possible.