### PR TITLE
Safari doesn't work with path restriction on session ID cookie - so r…

### DIFF
--- a/src/auth/oidc.ts
+++ b/src/auth/oidc.ts
@@ -288,7 +288,6 @@ export async function oidcLoginStart (req: express.Request, res: express.Respons
         // Create session key
         const sessionId = Array.from({length:32}, (_,i) => urlSafeChars[Math.floor(Math.random() * urlSafeChars.length)]).join("");
         res.cookie('sessionId', sessionId, {
-            path: (new URL(RuntimeConfig.apiAddress + '/auth/oidcCallback', ServerConfig.serverAddress)).href,
             maxAge: 600000,
             httpOnly: true,
             secure: !ServerConfig.httpOnly,


### PR DESCRIPTION
…emoving that limit

This fix resolves https://github.com/CARTAvis/carta-controller/issues/149

The session ID cookie was just being used for verifying the response from the OIDC server, and shouldn't pose a security risk to expose to other parts of the website for the few minutes that it lives, so removing that restriction from all browsers to avoid making this browser-specific.