### PR TITLE
Update Google auth approach to use new libraries

### DIFF
--- a/config/config_schema.json
+++ b/config/config_schema.json
@@ -34,7 +34,7 @@
                 "userLookupTable",
                 "publicKeyLocation",
                 "privateKeyLocation",
-                "keyAlgorithm",
+                "validDomain",
                 "issuer"
             ],
             "properties": {

--- a/config/config_schema.json
+++ b/config/config_schema.json
@@ -31,7 +31,11 @@
             "additionalProperties": false,
             "required": [
                 "clientId",
-                "userLookupTable"
+                "userLookupTable",
+                "publicKeyLocation",
+                "privateKeyLocation",
+                "keyAlgorithm",
+                "issuer"
             ],
             "properties": {
                 "clientId": {
@@ -65,6 +69,61 @@
                     "type": "string",
                     "examples": [
                         "/etc/carta/userlookup.txt"
+                    ]
+                },
+                "publicKeyLocation": {
+                    "description": "Path to public key (in PEM format) used for verifying JWTs",
+                    "type": "string",
+                    "examples": [
+                        "/etc/carta/carta_public.pem"
+                    ]
+                },
+                "privateKeyLocation": {
+                    "description": "Path to private key (in PEM format) used for signing JWTs",
+                    "type": "string",
+                    "examples": [
+                        "/etc/carta/carta_private.pem"
+                    ]
+                },
+                "keyAlgorithm": {
+                    "$ref": "#/definitions/keyAlgorithm",
+                    "default": "RS256"
+                },
+                "issuer": {
+                    "description": "Issuer field for JWT",
+                    "type": "string",
+                    "examples": [
+                        "my-carta-server"
+                    ]
+                },
+                "refreshTokenAge": {
+                    "description": "Lifetime of refresh tokens",
+                    "type": "string",
+                    "default": "1w",
+                    "examples": [
+                        "1w",
+                        "15h",
+                        "2d"
+                    ]
+                },
+                "accessTokenAge": {
+                    "description": "Lifetime of access tokens",
+                    "type": "string",
+                    "default": "15m",
+                    "examples": [
+                        "90s",
+                        "1h",
+                        "15m"
+                    ]
+                },
+                "scriptingTokenAge": {
+                    "description": "Lifetime of scripting tokens",
+                    "type": "string",
+                    "default": "1w",
+                    "examples": [
+                        "1w",
+                        "5d",
+                        "10h"
                     ]
                 }
             }

--- a/config/config_schema.json
+++ b/config/config_schema.json
@@ -34,7 +34,6 @@
                 "userLookupTable",
                 "publicKeyLocation",
                 "privateKeyLocation",
-                "validDomain",
                 "issuer"
             ],
             "properties": {

--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -43,7 +43,7 @@ The controller signs and validates tokens with SSL keys. You can generate a priv
     openssl genrsa -out carta_private.pem 4096
     openssl rsa -in carta_private.pem -outform PEM -pubout -out carta_public.pem
 
-A public/private keypair is used to authenticate access tokens. OIDC authentication requires an additional symmetric encryption key for refresh tokens. LDAP or PAM authentication uses the same public/private keypair both for access tokens and for refresh tokens. If you use the default encryption algorithm, you can again use `openssl` to generate the needed key:
+In addition to the keypair above for authenticating access tokens and refresh tokens, those using OIDC authentication require an additional symmetric encryption key. If you use the default encryption algorithm, you can again use `openssl` to generate the needed key:
 
 .. code-block:: shell
 

--- a/docs/src/introduction.rst
+++ b/docs/src/introduction.rst
@@ -25,7 +25,7 @@ Detailed installation instructions are available for :ref:`Ubuntu<focal_instruct
 Authentication support
 ----------------------
 
-The CARTA controller supports five modes for authentication. All four modes use refresh and access tokens, as described in the `OAuth2 Authorization flow <https://tools.ietf.org/html/rfc6749#section-1.3.1>`_, stored in `JWT <https://jwt.io/>`_ format. The modes are:
+The CARTA controller supports five modes for authentication. All five modes use refresh and access tokens, as described in the `OAuth2 Authorization flow <https://tools.ietf.org/html/rfc6749#section-1.3.1>`_, stored in `JWT <https://jwt.io/>`_ format. The modes are:
 
 * **PAM authentication**: The PAM interface of the host system is used for user authentication. After the user's username and password configuration are validated by PAM, ``carta-controller`` returns a long-lived refresh token, signed with a private key, which can be exchanged by the CARTA dashboard or the CARTA frontend client for a short-lived access token.
 * **LDAP authentication**: As above, but an LDAP server is used directly for user authentication.

--- a/docs/src/introduction.rst
+++ b/docs/src/introduction.rst
@@ -25,11 +25,12 @@ Detailed installation instructions are available for :ref:`Ubuntu<focal_instruct
 Authentication support
 ----------------------
 
-The CARTA controller supports four modes for authentication. All four modes use refresh and access tokens, as described in the `OAuth2 Authorization flow <https://tools.ietf.org/html/rfc6749#section-1.3.1>`_, stored in `JWT <https://jwt.io/>`_ format. The modes are:
+The CARTA controller supports five modes for authentication. All four modes use refresh and access tokens, as described in the `OAuth2 Authorization flow <https://tools.ietf.org/html/rfc6749#section-1.3.1>`_, stored in `JWT <https://jwt.io/>`_ format. The modes are:
 
 * **PAM authentication**: The PAM interface of the host system is used for user authentication. After the user's username and password configuration are validated by PAM, ``carta-controller`` returns a long-lived refresh token, signed with a private key, which can be exchanged by the CARTA dashboard or the CARTA frontend client for a short-lived access token.
 * **LDAP authentication**: As above, but an LDAP server is used directly for user authentication.
-* **Google authentication**: Google's authentication libraries are used for handling authentication. You must create a new web application in the `Google API console <https://console.developers.google.com/apis/credentials>`_. You will then use the  client ID provided by this application in a number of places during the configuration.
+* **Google authentication**: Google is used at time of login. You must create a new web application in the `Google API console <https://console.developers.google.com/apis/credentials>`_. You will then use the client ID created during the configuration.  You will also need to add a callback URI to your application - e.g. if your application is installed at "https://example.com", you'd want to specify "https://example.com/api/auth/googleCallback" as an authorized redirect URI.
+* **OIDC authentication**: An OIDC-compatible identity provider is used, such as keycloak.
 * **External authentication**: This allows users to authenticate with some external OAuth2-based authentication system. This requires a fair amount of configuration, and has not been well-tested. It is assumed that the refresh token passed by the authentication system is stored as an ``HttpOnly`` cookie.
 
 .. _getting_help:

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "crypto": "^1.0.1",
                 "express": "^4.17.1",
                 "express-bearer-token": "^2.4.0",
-                "google-auth-library": "^8.7.0",
+                "google-auth-library": "^9.4.2",
                 "hjson": "^3.2.2",
                 "http-proxy": "^1.18.1",
                 "jose": "^4.8.3",
@@ -4820,14 +4820,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/asap": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -5303,9 +5295,9 @@
             }
         },
         "node_modules/bignumber.js": {
-            "version": "9.1.1",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-            "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+            "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
             "engines": {
                 "node": "*"
             }
@@ -8235,11 +8227,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
         },
-        "node_modules/fast-text-encoding": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-            "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="
-        },
         "node_modules/fastq": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -8736,29 +8723,52 @@
             }
         },
         "node_modules/gaxios": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.2.tgz",
-            "integrity": "sha512-TjtV2AJOZoMQqRYoy5eM8cCQogYwazWNYLQ72QB0kwa6vHHruYkGmhhyrlzbmgNHK1dNnuP2WSH81urfzyN2Og==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.1.tgz",
+            "integrity": "sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==",
             "dependencies": {
                 "extend": "^3.0.2",
-                "https-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^7.0.1",
                 "is-stream": "^2.0.0",
-                "node-fetch": "^2.6.7"
+                "node-fetch": "^2.6.9"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14"
+            }
+        },
+        "node_modules/gaxios/node_modules/agent-base": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/gaxios/node_modules/https-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/gcp-metadata": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.2.0.tgz",
-            "integrity": "sha512-aFhhvvNycky2QyhG+dcfEdHBF0FRbYcf39s6WNHUDysKSrbJ5vuFbjydxBcmewtXeV248GP8dWT3ByPNxsyHCw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+            "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
             "dependencies": {
-                "gaxios": "^5.0.0",
+                "gaxios": "^6.0.0",
                 "json-bigint": "^1.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14"
             }
         },
         "node_modules/gensync": {
@@ -8950,36 +8960,19 @@
             }
         },
         "node_modules/google-auth-library": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.7.0.tgz",
-            "integrity": "sha512-1M0NG5VDIvJZEnstHbRdckLZESoJwguinwN8Dhae0j2ZKIQFIV63zxm6Fo6nM4xkgqUr2bbMtV5Dgo+Hy6oo0Q==",
+            "version": "9.4.2",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.4.2.tgz",
+            "integrity": "sha512-rTLO4gjhqqo3WvYKL5IdtlCvRqeQ4hxUx/p4lObobY2xotFW3bCQC+Qf1N51CYOfiqfMecdMwW9RIo7dFWYjqw==",
             "dependencies": {
-                "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
-                "fast-text-encoding": "^1.0.0",
-                "gaxios": "^5.0.0",
-                "gcp-metadata": "^5.0.0",
-                "gtoken": "^6.1.0",
-                "jws": "^4.0.0",
-                "lru-cache": "^6.0.0"
+                "gaxios": "^6.1.1",
+                "gcp-metadata": "^6.1.0",
+                "gtoken": "^7.0.0",
+                "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/google-p12-pem": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
-            "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
-            "dependencies": {
-                "node-forge": "^1.3.1"
-            },
-            "bin": {
-                "gp12-pem": "build/src/bin/gp12-pem.js"
-            },
-            "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14"
             }
         },
         "node_modules/gopd": {
@@ -9004,16 +8997,15 @@
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
         },
         "node_modules/gtoken": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
-            "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.0.1.tgz",
+            "integrity": "sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==",
             "dependencies": {
-                "gaxios": "^5.0.1",
-                "google-p12-pem": "^4.0.0",
+                "gaxios": "^6.0.0",
                 "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/gzip-size": {
@@ -21314,11 +21306,6 @@
                 "is-shared-array-buffer": "^1.0.2"
             }
         },
-        "arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
-        },
         "asap": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -21671,9 +21658,9 @@
             "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
         },
         "bignumber.js": {
-            "version": "9.1.1",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-            "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+            "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="
         },
         "binary-extensions": {
             "version": "2.2.0",
@@ -23842,11 +23829,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
         },
-        "fast-text-encoding": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-            "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="
-        },
         "fastq": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -24207,22 +24189,41 @@
             }
         },
         "gaxios": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.2.tgz",
-            "integrity": "sha512-TjtV2AJOZoMQqRYoy5eM8cCQogYwazWNYLQ72QB0kwa6vHHruYkGmhhyrlzbmgNHK1dNnuP2WSH81urfzyN2Og==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.1.tgz",
+            "integrity": "sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==",
             "requires": {
                 "extend": "^3.0.2",
-                "https-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^7.0.1",
                 "is-stream": "^2.0.0",
-                "node-fetch": "^2.6.7"
+                "node-fetch": "^2.6.9"
+            },
+            "dependencies": {
+                "agent-base": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+                    "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+                    "requires": {
+                        "debug": "^4.3.4"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+                    "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+                    "requires": {
+                        "agent-base": "^7.0.2",
+                        "debug": "4"
+                    }
+                }
             }
         },
         "gcp-metadata": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.2.0.tgz",
-            "integrity": "sha512-aFhhvvNycky2QyhG+dcfEdHBF0FRbYcf39s6WNHUDysKSrbJ5vuFbjydxBcmewtXeV248GP8dWT3ByPNxsyHCw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+            "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
             "requires": {
-                "gaxios": "^5.0.0",
+                "gaxios": "^6.0.0",
                 "json-bigint": "^1.0.0"
             }
         },
@@ -24359,27 +24360,16 @@
             }
         },
         "google-auth-library": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.7.0.tgz",
-            "integrity": "sha512-1M0NG5VDIvJZEnstHbRdckLZESoJwguinwN8Dhae0j2ZKIQFIV63zxm6Fo6nM4xkgqUr2bbMtV5Dgo+Hy6oo0Q==",
+            "version": "9.4.2",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.4.2.tgz",
+            "integrity": "sha512-rTLO4gjhqqo3WvYKL5IdtlCvRqeQ4hxUx/p4lObobY2xotFW3bCQC+Qf1N51CYOfiqfMecdMwW9RIo7dFWYjqw==",
             "requires": {
-                "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
-                "fast-text-encoding": "^1.0.0",
-                "gaxios": "^5.0.0",
-                "gcp-metadata": "^5.0.0",
-                "gtoken": "^6.1.0",
-                "jws": "^4.0.0",
-                "lru-cache": "^6.0.0"
-            }
-        },
-        "google-p12-pem": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
-            "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
-            "requires": {
-                "node-forge": "^1.3.1"
+                "gaxios": "^6.1.1",
+                "gcp-metadata": "^6.1.0",
+                "gtoken": "^7.0.0",
+                "jws": "^4.0.0"
             }
         },
         "gopd": {
@@ -24401,12 +24391,11 @@
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
         },
         "gtoken": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
-            "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.0.1.tgz",
+            "integrity": "sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==",
             "requires": {
-                "gaxios": "^5.0.1",
-                "google-p12-pem": "^4.0.0",
+                "gaxios": "^6.0.0",
                 "jws": "^4.0.0"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "crypto": "^1.0.1",
                 "express": "^4.17.1",
                 "express-bearer-token": "^2.4.0",
-                "google-auth-library": "^9.4.2",
+                "google-auth-library": "^9.6.0",
                 "hjson": "^3.2.2",
                 "http-proxy": "^1.18.1",
                 "jose": "^4.8.3",
@@ -8960,9 +8960,9 @@
             }
         },
         "node_modules/google-auth-library": {
-            "version": "9.4.2",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.4.2.tgz",
-            "integrity": "sha512-rTLO4gjhqqo3WvYKL5IdtlCvRqeQ4hxUx/p4lObobY2xotFW3bCQC+Qf1N51CYOfiqfMecdMwW9RIo7dFWYjqw==",
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.6.0.tgz",
+            "integrity": "sha512-bM/buCwCeYZjmnzGstwREu3BsnbmnuI064ZGur0NmHyXUxubWMJTCO9kxsyy4T6jdzacHJY3XQWHxX4D4Mc+EA==",
             "dependencies": {
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
@@ -24360,9 +24360,9 @@
             }
         },
         "google-auth-library": {
-            "version": "9.4.2",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.4.2.tgz",
-            "integrity": "sha512-rTLO4gjhqqo3WvYKL5IdtlCvRqeQ4hxUx/p4lObobY2xotFW3bCQC+Qf1N51CYOfiqfMecdMwW9RIo7dFWYjqw==",
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.6.0.tgz",
+            "integrity": "sha512-bM/buCwCeYZjmnzGstwREu3BsnbmnuI064ZGur0NmHyXUxubWMJTCO9kxsyy4T6jdzacHJY3XQWHxX4D4Mc+EA==",
             "requires": {
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "crypto": "^1.0.1",
         "express": "^4.17.1",
         "express-bearer-token": "^2.4.0",
-        "google-auth-library": "^9.4.2",
+        "google-auth-library": "^9.6.0",
         "hjson": "^3.2.2",
         "http-proxy": "^1.18.1",
         "jose": "^4.8.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "crypto": "^1.0.1",
         "express": "^4.17.1",
         "express-bearer-token": "^2.4.0",
-        "google-auth-library": "^8.7.0",
+        "google-auth-library": "^9.4.2",
         "hjson": "^3.2.2",
         "http-proxy": "^1.18.1",
         "jose": "^4.8.3",

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -312,16 +312,11 @@ window.onload = async () => {
         onLoginSucceeded(usp.get("oidcuser"), "oidc")
     } else if (usp.has("googleuser")) {
         await refreshLocalToken();
-
-        // Handle redirect params via cookie
         if (localStorage.getItem("redirectParams")) {
             redirectUrl += atob(localStorage.getItem("redirectParams"));
             localStorage.removeItem("redirectParams");
             autoRedirect = true;
-        } else {
-
         }
-
         onLoginSucceeded(usp.get("googleuser"), "google")
     } else if (usp.has("err")) {
         console.log(usp.get("err"));

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -189,20 +189,11 @@ handleServerStop = async () => {
 }
 
 handleLogout = async () => {
-    clearInterval(serverCheckHandle);
-    if (authenticationType === "oidc") {
-        window.open(`${apiBase}/auth/logout`, "_self");
-    } else {
-        await handleLocalLogout();
-    }
+    localStorage.removeItem("authenticationType");
     if (serverRunning) {
         await handleServerStop();
     }
-    showMessage();
-    showCartaForm(false);
-    showLoginForm(true);
-    localStorage.removeItem("authenticationType");
-    clearToken();
+    window.open(`${apiBase}/auth/logout`, "_self");
 }
 
 handleOpenCarta = () => {

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -312,10 +312,25 @@ window.onload = async () => {
         onLoginSucceeded(usp.get("oidcuser"), "oidc")
     } else if (usp.has("googleuser")) {
         await refreshLocalToken();
+
+        // Handle redirect params via cookie
+        if (localStorage.getItem("redirectParams")) {
+            redirectUrl += atob(localStorage.getItem("redirectParams"));
+            localStorage.removeItem("redirectParams");
+            autoRedirect = true;
+        } else {
+
+        }
+
         onLoginSucceeded(usp.get("googleuser"), "google")
     } else if (usp.has("err")) {
         console.log(usp.get("err"));
         notyf.open({type: "error", message: usp.get("err")});
+    }
+
+    // Store redirectParams in localStorage if using Google login
+    if (usp.has("redirectParams") && document.getElementById("g_id_onload")) {
+        localStorage.setItem("redirectParams", usp.get("redirectParams"));
     }
 
     // Hide open button if using popup

--- a/public/templated.css
+++ b/public/templated.css
@@ -185,11 +185,14 @@ button {
 
 .sso-buttons {
 	padding-bottom: 15px;
+
+	display: flex;
+	justify-content: center;
+	align-items: center;
 }
 
-.sso-buttons .g-signin2 div {
-	margin-left: auto;
-	margin-right: auto;
+.sso-buttons .g_id_signin div {
+	margin: 0 auto;
 }
 
 a {

--- a/src/auth/external.ts
+++ b/src/auth/external.ts
@@ -11,8 +11,8 @@ function populateUserMap(userMaps: Map<string, UserMap>, issuer: string | string
         for (let line of lines) {
             line = line.trim();
 
-            // Skip comments
-            if (line.startsWith("#")) {
+            // Skip comments and empty lines
+            if (line.startsWith("#") || !/\S/.test(line)) {
                 continue;
             }
 

--- a/src/auth/google.ts
+++ b/src/auth/google.ts
@@ -1,36 +1,83 @@
-import {CartaGoogleAuthConfig, Verifier} from "../types";
+import { eq, result } from "lodash";
+import { RuntimeConfig, ServerConfig } from "../config";
+import {CartaGoogleAuthConfig, ScriptingAccess, Verifier} from "../types";
 import {OAuth2Client} from "google-auth-library";
+import {generateToken, TokenType} from "./local";
+import {getUser, verifyToken} from "./index";
+import ms = require("ms");
+import * as express from "express";
 
-export const validGoogleIssuers = ["accounts.google.com", "https://accounts.google.com"];
+export async function googleCallbackHandler (req: express.Request, res: express.Response, authConf: CartaGoogleAuthConfig) {
+    // Check for g_csrf_token match between cookie and body
+    if (!req.cookies['g_csrf_token'] || !req.body['g_csrf_token'] || req.cookies['g_csrf_token'] !== req.body['g_csrf_token']) {
+        return res.status(400).json({'error': 'Missing or non-matching CSRF token'})
+    }
 
-export function generateGoogleVerifier(verifierMap: Map<string, Verifier>, authConf: CartaGoogleAuthConfig) {
-    const googleAuthClient = new OAuth2Client(authConf.clientId);
-    const verifier = async (cookieString: string) => {
-        const ticket = await googleAuthClient.verifyIdToken({
-            idToken: cookieString,
-            audience: authConf.clientId
-        });
-        const payload = ticket.getPayload();
+    const oAuth2Client = new OAuth2Client();
+    try {
+        const result = await oAuth2Client.verifyIdToken({idToken: req?.body?.credential, audience: authConf.clientId});
+        const payload = result.getPayload()
 
-        // Use either the email or the unique sub ID as the username
+        // Do the mapping
         const username = authConf.useEmailAsId ? payload?.email : payload?.sub;
 
         // check that username exists and email is verified
         if (!username || !payload?.email_verified) {
             console.log("Google auth rejected due to lack of unique ID or email verification");
-            return undefined;
+            return res.status(500).json({'error': 'An error occured processing your login'});
         }
-
+        
         // check that domain is valid
         if (authConf.validDomain && authConf.validDomain !== payload.hd) {
             console.log(`Google auth rejected due to incorrect domain: ${payload.hd}`);
-            return undefined;
+            return res.status(500).json({'error': 'An error occured processing your login'});
         }
 
-        return {...payload, username};
-    };
+        // create initial refresh token
+        const refreshToken = generateToken(authConf, username, TokenType.Refresh);
+        res.cookie("Refresh-Token", refreshToken, {
+            path: RuntimeConfig.authPath,
+            maxAge: ms(authConf.refreshTokenAge as string),
+            httpOnly: true,
+            secure: !ServerConfig.httpOnly,
+            sameSite: "strict"
+        });
 
-    for (const iss of validGoogleIssuers) {
-        verifierMap.set(iss, verifier);
+        return res.redirect(`${new URL(`${RuntimeConfig.dashboardAddress}`, ServerConfig.serverAddress).href}?googleuser=${username}`)
+
+    } catch (e) {
+        console.debug(e)
+        return res.status(500).json({'error': 'An error occured processing your login'})
     }
+}
+
+
+export function generateGoogleRefreshHandler(authConf: CartaGoogleAuthConfig) {
+    return async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        const refreshTokenCookie = req.cookies["Refresh-Token"];
+        const scriptingToken = req.body?.scripting === true;
+        if (refreshTokenCookie) {
+            try {
+                const refreshToken = await verifyToken(refreshTokenCookie);
+                if (!refreshToken || !refreshToken.username || !refreshToken.refresh) {
+                    next({statusCode: 403, message: "Not authorized"});
+                } else if (scriptingToken && ServerConfig.scriptingAccess !== ScriptingAccess.Enabled) {
+                    next({statusCode: 500, message: "Scripting access not enabled for this server"});
+                } else {
+                    const access_token = generateToken(authConf, refreshToken.username, scriptingToken ? TokenType.Scripting : TokenType.Access);
+                    console.log(`Refreshed ${scriptingToken ? "scripting" : "access"} token for user ${refreshToken.username}`);
+                    res.json({
+                        access_token,
+                        token_type: "bearer",
+                        username: refreshToken.username,
+                        expires_in: ms(scriptingToken ? authConf.scriptingTokenAge : (authConf.accessTokenAge as string)) / 1000
+                    });
+                }
+            } catch (err) {
+                next({statusCode: 400, message: "Invalid refresh token"});
+            }
+        } else {
+            next({statusCode: 400, message: "Missing refresh token"});
+        }
+    };
 }

--- a/src/auth/google.ts
+++ b/src/auth/google.ts
@@ -1,5 +1,4 @@
-import { eq, result } from "lodash";
-import { RuntimeConfig, ServerConfig } from "../config";
+import {RuntimeConfig, ServerConfig} from "../config";
 import {CartaGoogleAuthConfig, ScriptingAccess, Verifier} from "../types";
 import {OAuth2Client} from "google-auth-library";
 import {generateToken, TokenType} from "./local";

--- a/src/auth/google.ts
+++ b/src/auth/google.ts
@@ -42,7 +42,7 @@ export async function googleCallbackHandler (req: express.Request, res: express.
             sameSite: "strict"
         });
 
-        return res.redirect(`${new URL(`${RuntimeConfig.dashboardAddress}`, ServerConfig.serverAddress).href}?googleuser=${username}`)
+        return res.redirect(`${RuntimeConfig.dashboardAddress}?googleuser=${username}`)
 
     } catch (e) {
         console.debug(e)

--- a/src/auth/google.ts
+++ b/src/auth/google.ts
@@ -8,8 +8,8 @@ import * as express from "express";
 
 export async function googleCallbackHandler (req: express.Request, res: express.Response, authConf: CartaGoogleAuthConfig) {
     // Check for g_csrf_token match between cookie and body
-    if (!req.cookies['g_csrf_token'] || !req.body['g_csrf_token'] || req.cookies['g_csrf_token'] !== req.body['g_csrf_token']) {
-        return res.status(400).json({'error': 'Missing or non-matching CSRF token'})
+    if (!req.cookies["g_csrf_token"] || !req.body["g_csrf_token"] || req.cookies["g_csrf_token"] !== req.body["g_csrf_token"]) {
+        return res.status(400).json({"error": "Missing or non-matching CSRF token"})
     }
 
     const oAuth2Client = new OAuth2Client();
@@ -23,13 +23,13 @@ export async function googleCallbackHandler (req: express.Request, res: express.
         // check that username exists and email is verified
         if (!username || !payload?.email_verified) {
             console.log("Google auth rejected due to lack of unique ID or email verification");
-            return res.status(500).json({'error': 'An error occured processing your login'});
+            return res.status(500).json({"error": "An error occured processing your login"});
         }
         
         // check that domain is valid
         if (authConf.validDomain && authConf.validDomain !== payload.hd) {
             console.log(`Google auth rejected due to incorrect domain: ${payload.hd}`);
-            return res.status(500).json({'error': 'An error occured processing your login'});
+            return res.status(500).json({"error": "An error occured processing your login"});
         }
 
         // create initial refresh token
@@ -46,7 +46,7 @@ export async function googleCallbackHandler (req: express.Request, res: express.
 
     } catch (e) {
         console.debug(e)
-        return res.status(500).json({'error': 'An error occured processing your login'})
+        return res.status(500).json({"error": "An error occured processing your login"})
     }
 }
 

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -125,13 +125,7 @@ function logoutHandler(req: express.Request, res: express.Response) {
         secure: !ServerConfig.httpOnly,
         sameSite: "strict"
     });
-    if (RuntimeConfig.dashboardAddress) {
-        return res.redirect(new URL(`${RuntimeConfig.dashboardAddress}`, ServerConfig.serverAddress).href);
-    } else if (ServerConfig.serverAddress) {
-        return res.redirect(ServerConfig.serverAddress);
-    } else {
-        return res.json({status: "Logged out"});
-    }
+        return res.redirect(`${RuntimeConfig.dashboardAddress}`);
 }
 
 function handleCheckAuth(req: AuthenticatedRequest, res: express.Response) {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -125,7 +125,13 @@ function logoutHandler(req: express.Request, res: express.Response) {
         secure: !ServerConfig.httpOnly,
         sameSite: "strict"
     });
-    return res.json({success: true});
+    if (RuntimeConfig.dashboardAddress) {
+        return res.redirect(new URL(`${RuntimeConfig.dashboardAddress}`, ServerConfig.serverAddress).href);
+    } else if (ServerConfig.serverAddress) {
+        return res.redirect(ServerConfig.serverAddress);
+    } else {
+        return res.json({status: "Logged out"});
+    }
 }
 
 function handleCheckAuth(req: AuthenticatedRequest, res: express.Response) {
@@ -142,11 +148,11 @@ if (ServerConfig.authProviders.oidc) {
     authRouter.get("/login", noCache, loginHandler);
 } else if (ServerConfig.authProviders.google) {
     authRouter.post("/googleCallback", noCache, callbackHandler);
-    authRouter.post("/logout", noCache, logoutHandler);
+    authRouter.get("/logout", noCache, logoutHandler);
 }
 else {
     authRouter.post("/login", noCache, loginHandler);
-    authRouter.post("/logout", noCache, logoutHandler);
+    authRouter.get("/logout", noCache, logoutHandler);
 }
 authRouter.post("/refresh", noCache, refreshHandler);
 authRouter.get("/status", authGuard, noCache, handleCheckAuth);

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,6 +122,5 @@ if (runtimeConfig.tokenRefreshAddress) {
     const authUrl = url.parse(runtimeConfig.tokenRefreshAddress);
     runtimeConfig.authPath = authUrl.pathname ?? "";
 }
-runtimeConfig.logoutUsingGet = serverConfig.authProviders.oidc !== undefined;
 
 export {serverConfig as ServerConfig, runtimeConfig as RuntimeConfig, testUser, verboseOutput};

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,6 @@ import * as _ from "lodash";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import {CartaCommandLineOptions, CartaRuntimeConfig, CartaServerConfig} from "./types";
-import { server } from "websocket";
 
 const defaultConfigPath = "/etc/carta/config.json";
 const argv = yargs.options({

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ import * as _ from "lodash";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import {CartaCommandLineOptions, CartaRuntimeConfig, CartaServerConfig} from "./types";
+import { server } from "websocket";
 
 const defaultConfigPath = "/etc/carta/config.json";
 const argv = yargs.options({
@@ -111,9 +112,7 @@ if (!serverConfig.baseFolderTemplate) {
 const runtimeConfig: CartaRuntimeConfig = {};
 runtimeConfig.dashboardAddress = serverConfig.dashboardAddress || "/dashboard";
 runtimeConfig.apiAddress = serverConfig.apiAddress || "/api";
-if (serverConfig.authProviders.google) {
-    runtimeConfig.googleClientId = serverConfig.authProviders.google.clientId;
-} else if (serverConfig.authProviders.external) {
+if (serverConfig.authProviders.external) {
     runtimeConfig.tokenRefreshAddress = serverConfig.authProviders.external.tokenRefreshAddress;
     runtimeConfig.logoutAddress = serverConfig.authProviders.external.logoutAddress;
 } else {
@@ -124,5 +123,6 @@ if (runtimeConfig.tokenRefreshAddress) {
     const authUrl = url.parse(runtimeConfig.tokenRefreshAddress);
     runtimeConfig.authPath = authUrl.pathname ?? "";
 }
+runtimeConfig.logoutUsingGet = serverConfig.authProviders.oidc !== undefined;
 
 export {serverConfig as ServerConfig, runtimeConfig as RuntimeConfig, testUser, verboseOutput};

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ if (testUser) {
             googleClientId: ServerConfig.authProviders.google?.clientId,
             oidcClientId: ServerConfig.authProviders.oidc?.clientId,
             hostedDomain: ServerConfig.authProviders.google?.validDomain,
+            googleCallback: ServerConfig.serverAddress + '/api/auth/googleCallback',
             bannerColor: ServerConfig.dashboard?.bannerColor,
             backgroundColor: ServerConfig.dashboard?.backgroundColor,
             bannerImage: bannerDataUri,

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,7 +161,6 @@ export interface CartaRuntimeConfig {
     apiAddress?: string;
     tokenRefreshAddress?: string;
     logoutAddress?: string;
-    logoutUsingGet?: boolean;
     authPath?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface CartaLdapAuthConfig extends CartaLocalAuthConfig {
     ldapOptions: LdapAuth.Options;
 }
 
-export interface CartaGoogleAuthConfig {
+export interface CartaGoogleAuthConfig extends CartaLocalAuthConfig {
     clientId: string;
     // Valid domain to accept. If this is empty or undefined, all domains are accepted. Domain specified by "hd" field
     validDomain?: string;
@@ -159,9 +159,9 @@ export interface CartaCommandLineOptions {
 export interface CartaRuntimeConfig {
     dashboardAddress?: string;
     apiAddress?: string;
-    googleClientId?: string;
     tokenRefreshAddress?: string;
     logoutAddress?: string;
+    logoutUsingGet?: boolean;
     authPath?: string;
 }
 

--- a/views/templated.pug
+++ b/views/templated.pug
@@ -4,11 +4,7 @@ html
         meta(charset="UTF-8")
         title CARTA Dashboard
         if googleClientId
-            meta(name='google-signin-scope' content='profile email')
-            meta(name='google-signin-client_id' content=googleClientId)
-            if hostedDomain
-                meta(name='google-signin-hosted_domain' content=hostedDomain)
-            script(src='https://apis.google.com/js/platform.js?onload=initGoogleAuth' async='' defer='')
+            script(src='https://accounts.google.com/gsi/client' async defer)
         link(href="dashboard/templated.css" rel="stylesheet" type="text/css")
         link(rel='stylesheet' href='dashboard/notyf.min.css')
         link(rel='shortcut icon' href='dashboard/carta_icon_128px.png')
@@ -38,7 +34,8 @@ html
                             | !{loginText}
                     if googleClientId
                         .sso-buttons
-                            .g-signin2(data-onsuccess='onSignIn' data-theme='dark' data-width="220" data-height="46")
+                            div#g_id_onload(data-client_id=googleClientId, data-ux_mode="redirect" data-login_uri=googleCallback data-auto_prompt='false')
+                            .g_id_signin(data-type="standard" data-size="large" data-theme="filled_blue" data-width="220" data-height="46")
                     else if oidcClientId
                         .formcontainer
                             button.button.button-signin#oidcLogin SIGN IN


### PR DESCRIPTION
**NOTE: This is a breaking change for those using Google auth and will require updates to your config and Google auth registration as well as a frontend using the code associated with the [corresponding frontend pull request](https://github.com/CARTAvis/carta-frontend/pull/2345) to work.**

The Google auth approach now has the controller accept an ID token from Google at a callback address, and then based on this generates locally-issued refresh tokens + access tokens similar to the other supported authentication approaches as since [per the migration docs](https://developers.google.com/identity/oauth2/web/guides/migration-to-gis#session_state) we now need to maintain session state.

Use of this updated controller requires changes to both the Google oauth client registration and the local controller configuration.

Adding the callback URL to the [oauth client configuration in the Google API console is needed](https://console.developers.google.com/apis/credentials).  If modifying an existing client, you'll need to add a "Authorized redirect URI".  If your app is installed at `https://example.com`, this would be `https://example.com/api/auth/googleCallback`.

As far as the local configuration is concerned the controller new requires the existance of a public/private keypair to sign its tokens, which can be generated [as already described in the documentation](https://carta-controller.readthedocs.io/en/latest/configuration.html#authentication).

The `google` block in the `authProviders` section of your CARTA config should be updated to look something like the following:
```
        "google":
                 {
                     "clientId": "my-client-id.apps.googleusercontent.com",
                     "validDomain": "example.com",
                     "publicKeyLocation": "/etc/carta/carta_public.pem",
                     "privateKeyLocation": "/etc/carta/carta_private.pem",
                     "issuer": "carta.example.com",
                     "userLookupTable": "/etc/carta/userlookup.txt",
                 }
```
`clientId` should be the value shown in the Google dashboard, and `validDomain` can be used to used to restrict the list of permitted users to those associated with a particular Google workspace / cloud organizational account.  Note that user lookups retain a similar functionality to what was there before, defaulting to the use of mapping using the verified email addresses returned for the user.  (`publicKeyLocation`, `privateKeyLocation`, and `issuer` now appear similar to how they appear when using other mechanisms, and should be similar filled in using the locations for the public/private keypair and how CARTA will identify itself in the tokens it's signing, with the hostname as a suggestion).