### PR TITLE
Prevent Mongo password from being logged in plain text

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -6,7 +6,6 @@ import {authGuard} from "./auth";
 import {noCache, verboseError} from "./util";
 import {AuthenticatedRequest} from "./types";
 import {ServerConfig} from "./config";
-import url = require('url');
 
 const PREFERENCE_SCHEMA_VERSION = 2;
 const LAYOUT_SCHEMA_VERSION = 2;
@@ -64,11 +63,12 @@ export async function initDB() {
             await updateUsernameIndex(workspacesCollection, false);
             await updateUsernameIndex(preferenceCollection, true);
 
-            const parsedUri = new url.URL(ServerConfig.database.uri);
-            if (parsedUri.password) {
-                parsedUri.password = '***';
+            const lastAt = ServerConfig.database.uri.lastIndexOf('@');
+            let mongoTarget = ServerConfig.database.uri;
+            if (lastAt !== -1) {
+                mongoTarget = ServerConfig.database.uri.slice(lastAt + 1)
             }
-            console.log(`Connected to server ${parsedUri} and database ${ServerConfig.database.databaseName}`);
+            console.log(`Connected to server ${mongoTarget} and database ${ServerConfig.database.databaseName}`);
         } catch (err) {
             verboseError(err);
             console.error("Error connecting to database");

--- a/src/database.ts
+++ b/src/database.ts
@@ -63,14 +63,7 @@ export async function initDB() {
             await updateUsernameIndex(workspacesCollection, false);
             await updateUsernameIndex(preferenceCollection, true);
 
-            const lastAt = ServerConfig.database.uri.lastIndexOf('@');
-            let mongoTarget = ServerConfig.database.uri;
-            if (lastAt !== -1) {
-                mongoTarget = ServerConfig.database.uri.slice(lastAt + 1)
-            } else {
-                mongoTarget = ServerConfig.database.uri.replace('mongodb://', '')
-            }
-            console.log(`Connected to server ${mongoTarget} and database ${ServerConfig.database.databaseName}`);
+            console.log(`Connected to ${client.options.dbName} on ${client.options.hosts} (Authenticated: ${client.options.credentials ? 'Yes': 'No'})`);
         } catch (err) {
             verboseError(err);
             console.error("Error connecting to database");

--- a/src/database.ts
+++ b/src/database.ts
@@ -67,6 +67,8 @@ export async function initDB() {
             let mongoTarget = ServerConfig.database.uri;
             if (lastAt !== -1) {
                 mongoTarget = ServerConfig.database.uri.slice(lastAt + 1)
+            } else {
+                mongoTarget = ServerConfig.database.uri.replace('mongodb://', '')
             }
             console.log(`Connected to server ${mongoTarget} and database ${ServerConfig.database.databaseName}`);
         } catch (err) {

--- a/src/database.ts
+++ b/src/database.ts
@@ -6,6 +6,7 @@ import {authGuard} from "./auth";
 import {noCache, verboseError} from "./util";
 import {AuthenticatedRequest} from "./types";
 import {ServerConfig} from "./config";
+import url = require('url');
 
 const PREFERENCE_SCHEMA_VERSION = 2;
 const LAYOUT_SCHEMA_VERSION = 2;
@@ -62,7 +63,12 @@ export async function initDB() {
             await updateUsernameIndex(snippetsCollection, false);
             await updateUsernameIndex(workspacesCollection, false);
             await updateUsernameIndex(preferenceCollection, true);
-            console.log(`Connected to server ${ServerConfig.database.uri} and database ${ServerConfig.database.databaseName}`);
+
+            const parsedUri = new url.URL(ServerConfig.database.uri);
+            if (parsedUri.password) {
+                parsedUri.password = '***';
+            }
+            console.log(`Connected to server ${parsedUri} and database ${ServerConfig.database.databaseName}`);
         } catch (err) {
             verboseError(err);
             console.error("Error connecting to database");


### PR DESCRIPTION
The current codebase works with remote and password-protected MongoDB servers but logs the full credentials used to access the server in the controller logs.

This pull request keeps the credentials associated with Mongo from being logged.  Initially URL parsing was used, but the URL parser would error if using [Mongo's replica set syntax](https://www.mongodb.com/docs/manual/reference/connection-string/#replica-set-option) so doing something simple for now.