### PR TITLE
Update recommended node versions in 4.0 docs.

### DIFF
--- a/docs/src/almalinux8_instructions.rst
+++ b/docs/src/almalinux8_instructions.rst
@@ -11,12 +11,12 @@ Step-by-step instructions for AlmaLinux 8
 1. Install Node.js
 ~~~~~~~~~~~~~~~~~~
 
-The CARTA controller uses `Node.js <https://nodejs.org/>`_ and supports v12, v14, and v16. Node.js can easily be installed from the AlmaLinux 8 AppStream repository. Here we install v14, as well as the ``npm`` package manager.
+The CARTA controller uses `Node.js <https://nodejs.org/>`_, which can easily be installed from the AlmaLinux 8 AppStream repository. We recommend using the `latest LTS version <https://github.com/nodejs/release#release-schedule>`_. The oldest version known to work with the controller is v16. Here we install v20, as well as the ``npm`` package manager.
 
 .. code-block:: shell
 
-    # Install Node.js v14:
-    sudo dnf module enable nodejs:14
+    # Install Node.js v20:
+    sudo dnf module enable nodejs:20
     sudo dnf install -y nodejs npm
 
     # Check it is installed and working:

--- a/docs/src/ubuntu_focal_instructions.rst
+++ b/docs/src/ubuntu_focal_instructions.rst
@@ -74,7 +74,7 @@ Install CARTA controller
 
 .. note::
 
-    Currently supported versions of NodeJS are v12, v14 and v16. In the example below we install the latest LTS version of NodeJS from the `NodeSource repo <https://github.com/nodesource/distributions>`_. Do not pass the ``--unsafe-perm`` flag to ``npm`` if using a local install.
+    We recommend using the `latest LTS version <https://github.com/nodejs/release#release-schedule>`_ of NodeJS. The oldest version known to work with the controller is v16. In the example below we install the latest LTS version from the `NodeSource repo <https://github.com/nodesource/distributions>`_. Do not pass the ``--unsafe-perm`` flag to ``npm`` if using a local install.
 
 .. code-block:: shell
 


### PR DESCRIPTION
This is a backport of only the documentation changes from #171.