### PR TITLE
Update error message to remove LDAP reference

### DIFF
--- a/src/controllerTests.ts
+++ b/src/controllerTests.ts
@@ -130,10 +130,10 @@ function testToken(authConf: CartaLocalAuthConfig, username: string) {
         token = generateToken(authConf, username, TokenType.Access);
     } catch (e) {
         verboseError(e);
-        throw new Error(`Cannot generate access token. Please check your config file's ldap auth section!`);
+        throw new Error("Cannot generate access token. Please check your config file's auth section!");
     }
     if (!token) {
-        throw new Error(`Invalid access token. Please check your config file's ldap auth section!`);
+        throw new Error("Invalid access token. Please check your config file's auth section!");
     }
     console.log(logSymbols.success, `Generated access token for user ${username}`);
 }


### PR DESCRIPTION
Going through old issues to see what can be cleaned up and noticed #120 which highlighted an additional issue with controller test logging (and which was still unresolved after merging https://github.com/CARTAvis/carta-controller/pull/190 yesterday.  Here I've gone and removed the LDAP reference but kept the auth section reference there - is this enough to address the issue?