### PR TITLE
Update yargs parser config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,23 +14,23 @@ const argv = yargs
         'short-option-groups': false,
     })
     .options({
-    config: {
-        type: "string",
-        default: defaultConfigPath,
-        alias: "c",
-        description: "Path to config file in JSON format"
-    },
-    test: {
-        type: "string",
-        alias: "t",
-        requiresArg: true,
-        description: "Test configuration with the provided user"
-    },
-    verbose: {
-        type: "boolean",
-        alias: "v"
-    }
-}).argv as CartaCommandLineOptions;
+        config: {
+            type: "string",
+            default: defaultConfigPath,
+            alias: "c",
+            description: "Path to config file in JSON format"
+        },
+        test: {
+            type: "string",
+            alias: "t",
+            requiresArg: true,
+            description: "Test configuration with the provided user"
+        },
+        verbose: {
+            type: "boolean",
+            alias: "v"
+        }
+    }).argv as CartaCommandLineOptions;
 
 const usingCustomConfig = argv.config !== defaultConfigPath;
 const testUser = argv.test;

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,11 @@ import addFormats from "ajv-formats";
 import {CartaCommandLineOptions, CartaRuntimeConfig, CartaServerConfig} from "./types";
 
 const defaultConfigPath = "/etc/carta/config.json";
-const argv = yargs.options({
+const argv = yargs
+    .parserConfiguration({
+        'short-option-groups': false,
+    })
+    .options({
     config: {
         type: "string",
         default: defaultConfigPath,


### PR DESCRIPTION
I was trying to reproduce #121 and noticed that I encountered a different error, though one which may or may not be similarly resolved with this same fix.

```
$ npx ts-node src/index.ts -test ubuntu
Checking config file /etc/carta/config.json
Using /etc/carta/userlookupOidc.txt for user mapping
Updated usermap with 3 entries
Testing configuration with user ,ubuntu
✔ Checked database connection
✔ Checked log writing for user ,ubuntu
✔ Read frontend index.html from /home/ubuntu/carta-controller/node_modules/carta-frontend/build
Setting up JWKS management for https://...
sudo: unknown user ,ubuntu
sudo: error initializing audit plugin sudoers_audit
✔ Backend process started successfully
✖ Error: Cannot connect to backend process. Please check your additionalArgs section. If sudo is prompting you for a password, please check your sudoers config
Controller tests with user ,ubuntu failed
```

After making the modification here it seems that I get the desired result whether I launch with `--test` or `-test` - i.e. it seems to work with either.  Guessing that this may be a situation in which the current yargs just errors in a different fashion, so if merging this in I think we can close #121 as well.