### PR TITLE
Fix dev branch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "carta-controller",
-    "version": "4.1.0",
+    "version": "5.0.0-dev",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "carta-controller",
-            "version": "4.1.0",
+            "version": "5.0.0-dev",
             "license": "ISC",
             "dependencies": {
                 "@pm2/io": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "carta-controller",
-    "version": "4.1.0",
+    "version": "5.0.0-dev",
     "description": "NodeJS-based controller for CARTA",
     "repository": "https://github.com/CARTAvis/carta-controller",
     "homepage": "https://www.cartavis.org",


### PR DESCRIPTION
This repo should match the new convention used in the backend and frontend. Summary:
* dev branch version is always `NEXTRELEASE-dev`
* beta release: create branch called `release/NEXTRELEASE` from dev; change version in that branch to `NEXTRELEASE-beta.1`
* stable release: change version in `release/NEXTRELEASE` to `NEXTRELEASE`
* after stable release: change version in dev to `NEWNEXTRELEASE-dev`