### PR TITLE
Revert changes to api mounts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,9 @@ if (testUser) {
     app.use(compression());
     app.set("view engine", "pug");
     app.set("views", path.join(__dirname, "../views"));
-    app.use(`${RuntimeConfig.apiAddress}/auth`, bodyParser.json(), authRouter);
-    app.use(`${RuntimeConfig.apiAddress}/server`, bodyParser.json(), serverRouter);
-    app.use(`${RuntimeConfig.apiAddress}/database`, bodyParser.json(), databaseRouter);
+    app.use("/api/auth", bodyParser.json(), authRouter);
+    app.use("/api/server", bodyParser.json(), serverRouter);
+    app.use("/api/database", bodyParser.json(), databaseRouter);
 
     app.use("/config", (req: Request, res: Response) => {
         return res.json(RuntimeConfig);
@@ -104,7 +104,7 @@ if (testUser) {
 
     // Scripting proxy
     const backendProxy = httpProxy.createServer({ws: true});
-    app.post(`${RuntimeConfig.apiAddress}/scripting/*`, authGuard, createScriptingProxyHandler(backendProxy));
+    app.post("/api/scripting/*", authGuard, createScriptingProxyHandler(backendProxy));
 
     // Simplified error handling
     app.use((err: any, req: Request, res: Response, next: NextFunction) => {


### PR DESCRIPTION
For the moment switch back to the old routing approach for the API components as these settings seem at the moment to only be useful for configuring CARTA mounted at a path other than `/` (as might be the case if hidden behind a reverse proxy).

It should be possible to rewrite the remaining code to use relative URLs for such references, but since the original intention had been to use make these elements more pluginable, it doesn't seem to make sense to consolidate them at present, particularly since there are existing installations using this approach.