### PR TITLE
Enable ANSI colours in controller test output in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/**/*.js
 dist/**/*.js.map
 carta-controller-*.tgz
 docs/_build
+__pycache__/
+*.pyc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==5.1.0
 sphinx-jsonschema==1.19.1
 sphinx-rtd-theme==1.0.0
 sphinx-tabs==3.4.5
+pygments-ansi-color==0.3.0

--- a/docs/src/_static/output/alicetest.txt
+++ b/docs/src/_static/output/alicetest.txt
@@ -1,0 +1,21 @@
+Checking config file /etc/carta/config.json
+Testing configuration with user [1malice[22m
+[1G[0JPassword for user alice: [26G[32m✔[39m Checked PAM connection for user alice
+[32m✔[39m Verified uid (1001) for user alice
+[32m✔[39m Generated access token for user alice
+[32m✔[39m Checked database connection
+[32m✔[39m Checked log writing for user alice
+[32m✔[39m Read frontend index.html from /usr/lib/node_modules/carta-controller/dist/../node_modules/carta-frontend/build
+[
+  [32m'running sudo --preserve-env=CARTA_AUTH_TOKEN -n -u alice /usr/bin/carta_backend --no_frontend --no_database --debug_no_auth --port 3499 --top_level_folder /home/alice --controller_deployment --no_log /home/alice'[39m
+]
+[2025-06-03 11:42:26.470Z] [CARTA] [[32minfo[m] /usr/bin/carta_backend: Version 5.0.0-dev
+[2025-06-03 11:42:26.471Z] [CARTA] [[32minfo[m] Listening on port 3499 with top level folder /home/alice, starting folder /home/alice, and 8 OpenMP worker threads
+[32m✔[39m Backend process started successfully
+[2025-06-03 11:42:28.424Z] [CARTA] [[32minfo[m] 0x559910393af0 ::Session (1610787697:1)
+[2025-06-03 11:42:28.424Z] [CARTA] [[32minfo[m] Session 1610787697 [127.0.0.1] Connected. Num sessions: 1
+[32m✔[39m Backend process accepted connection
+[
+  [32m'running sudo -u alice /usr/bin/carta-kill-script 451830'[39m
+]
+[32m✔[39m Backend process killed correctly

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
@@ -44,6 +44,10 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# Custom style which extends the default Pygments style set by the RTD theme
+# with ANSI colour codes from the pygments ANSI extension
+
+pygments_style = 'style.DefaultAnsiStyle'
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -137,31 +137,9 @@ Testing the configuration
 
 To test the configuration of the controller, you can use the built-in test feature. Run ``carta-controller --verbose --test <username>`` as the ``carta`` user (or whichever user has the :ref:`added sudoers permissions<config-backend-permissions>`). ``<username>`` should be a user in the ``carta-users`` group. The expected output looks like this:
 
-.. code-block::
-
-    Checking config file /etc/carta/config.json
-    Adding additional config file config.d/pam.json
-    No top-level folder was specified. Reverting to default location
-    Testing configuration with user alice
-    Password for user alice:
-    ✔ Checked PAM connection for user alice
-    ✔ Verified uid (1000) for user alice
-    ✔ Generated access token for user alice
-    ✔ Checked database connection
-    ✔ Checked log writing for user alice
-    ✔ Read frontend index.html from /custom/frontend/path/build
-    [
-    'running sudo --preserve-env=CARTA_AUTH_TOKEN -n -u alice /usr/bin/carta_backend --no_http --debug_no_auth --port 3499 --top_level_folder /usr/share/carta --no_log /usr/share/carta'
-    ]
-    [2024-01-19 08:30:05.888Z] [CARTA] [info] /usr/bin/carta_backend: Version 4.1.0
-    [2024-01-19 08:30:05.888Z] [CARTA] [info] Listening on port 3499 with top level folder /usr/share/carta, starting folder /usr/share/carta, and 8 OpenMP worker threads
-    ✔ Backend process started successfully
-    [2024-01-19 08:30:07.850Z] [CARTA] [info] 0x561f1a635180 ::Session (1235524527:1)
-    [2024-01-19 08:30:07.850Z] [CARTA] [info] Session 1235524527 [127.0.0.1] Connected. Num sessions: 1
-    ✔ Backend process accepted connection
-    [ 'running sudo -u alice ./scripts/carta_kill_script.sh 54275' ]
-    ✔ Backend process killed correctly
-    Controller tests with user alice succeeded
+.. literalinclude:: _static/output/alicetest.txt
+   :language: ansi-color
+   :name: controller_test_output
 
 .. note::
     If you run the controller from a source directory using ``npm``, use ``--`` to ensure that any commandline parameters are passed to the controller and not to ``npm``. For example: ``npm start -- --verbose --test alice``.

--- a/docs/src/style.py
+++ b/docs/src/style.py
@@ -1,0 +1,6 @@
+from pygments.styles.default import DefaultStyle
+from pygments_ansi_color import color_tokens
+
+class DefaultAnsiStyle(DefaultStyle):
+    styles = dict(DefaultStyle.styles)
+    styles.update(color_tokens())


### PR DESCRIPTION
A minor style fix (see the configuration page in the docs). I also updated the output text to make the paths as "normal" as possible.