### PR TITLE
v5 release docs fixes (release branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # CARTA Controller
-
-[![carta version](https://img.shields.io/badge/CARTA%20Version-4.1.0-brightgreen)](https://github.com/CARTAvis/carta-backend/releases/tag/v4.1.0)
-[![npm version](https://img.shields.io/npm/v/carta-controller?style=flat)](https://npmjs.org/package/carta-controller "View this project on npm")
+<!-- These badges should only be uncommented in release branches, and point to the appropriate tags: -->
+<!--[![CARTA version](https://img.shields.io/badge/CARTA%20release-RELEASE-brightgreen)](https://github.com/CARTAvis/carta/releases/tag/vRELEASE)-->
+<!--[![npm package](https://img.shields.io/npm/v/carta-controller?style=flat)](https://www.npmjs.com/package/carta-controller/v/RELEASE)-->
+<!-- These badges should only be uncommented in dev, and updated with the dev version: -->
+[![CARTA backend version](https://img.shields.io/badge/CARTA%20backend%20version-6.0.0--dev-brightgreen)](https://github.com/CARTAvis/carta-backend/)
+[![CARTA frontend version](https://img.shields.io/badge/CARTA%20frontend%20version-6.0.0--dev-brightgreen)](https://github.com/CARTAvis/carta-frontend/)
 ![last commit](https://img.shields.io/github/last-commit/CARTAvis/carta-controller)
 ![commit activity](https://img.shields.io/github/commit-activity/m/CARTAvis/carta-controller)
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # CARTA Controller
 <!-- These badges should only be uncommented in release branches, and point to the appropriate tags: -->
-<!--[![CARTA version](https://img.shields.io/badge/CARTA%20release-RELEASE-brightgreen)](https://github.com/CARTAvis/carta/releases/tag/vRELEASE)-->
-<!--[![npm package](https://img.shields.io/npm/v/carta-controller?style=flat)](https://www.npmjs.com/package/carta-controller/v/RELEASE)-->
+[![CARTA version](https://img.shields.io/badge/CARTA%20release-5.0.0-brightgreen)](https://github.com/CARTAvis/carta/releases/tag/v5.0.0)
+[![npm package](https://img.shields.io/npm/v/carta-controller/latest?style=flat)](https://www.npmjs.com/package/carta-controller/v/latest)
 <!-- These badges should only be uncommented in dev, and updated with the dev version: -->
-[![CARTA backend version](https://img.shields.io/badge/CARTA%20backend%20version-6.0.0--dev-brightgreen)](https://github.com/CARTAvis/carta-backend/)
+<!--[![CARTA backend version](https://img.shields.io/badge/CARTA%20backend%20version-6.0.0--dev-brightgreen)](https://github.com/CARTAvis/carta-backend/)
 [![CARTA frontend version](https://img.shields.io/badge/CARTA%20frontend%20version-6.0.0--dev-brightgreen)](https://github.com/CARTAvis/carta-frontend/)
 ![last commit](https://img.shields.io/github/last-commit/CARTAvis/carta-controller)
-![commit activity](https://img.shields.io/github/commit-activity/m/CARTAvis/carta-controller)
+![commit activity](https://img.shields.io/github/commit-activity/m/CARTAvis/carta-controller)-->
 
 The CARTA controller provides a simple dashboard which authenticates users and allows them to manage their CARTA backend processes. It also serves static frontend code to clients, and dynamically redirects authenticated client connections to the appropriate backend processes. The controller can either handle authentication itself, or delegate it to an external OAuth2-based authentication server.
 

--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -104,13 +104,13 @@ You can alter the controller's dashboard appearance by adjusting the ``dashboard
 
 The ``httpOnly`` flag can be used to disable secure signing of authentication tokens. This should only be used during initial deployment and testing, or debugging.
 
-The controller assumes it is running at the root directory of your subdomain by default. If you would prefer to run on a subdirectory, you will need to specify the ``dashboardAddress`` and ``apiAddress`` values (relative to your subdomain) explicitly. For example, if you are hosting CARTA at ``https://subdomain.domain.com/carta/version/v3-beta/``, you would need to include the following in your config file:
+The controller assumes it is running at the root directory of your subdomain by default. If you would prefer to run on a subdirectory, you will need to specify the ``dashboardAddress`` and ``apiAddress`` values (relative to your subdomain) explicitly. For example, if you are hosting CARTA at ``https://subdomain.domain.com/carta/version/latest/``, you would need to include the following in your config file:
 
 .. code-block:: json
 
     {
-        "apiAddress": "/carta/version/v3-beta/api",
-        "dashboardAddress": "/carta/version/v3-beta/dashboard"
+        "apiAddress": "/carta/version/latest/api",
+        "dashboardAddress": "/carta/version/latest/dashboard"
     }
 
 The example controller configuration file enables logging to ``/var/log/carta/controller.log``, but the ``logFile`` field is optional and by default the controller will log only to the console. For logging to the example logfile location to work, you must ensure that the ``/var/log/carta`` directory exists and that the user account which is used to run the server has write permission to the log file.  It is also recommended to set up log rotation for this file, to prevent it from growing indefinitely. An example logrotate configuration is provided, which you can place in ``/etc/logrotate.d/carta-controller``:

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -6,13 +6,23 @@
 CARTA Controller
 ================
 
-|backend-github| |npm-package| |last-commit| |commit-activity|
+..
+        These badges should be uncommented only in the dev branch.
+        Don't forget to update the dev version in the definitions below.
+
+|backend-github| |frontend-github| |controller-github| |last-commit| |commit-activity|
+
+..
+        These badges should be uncommented only in release branches.
+        Don't forget to update the versions and tags in the definitions below.
+
+        |carta-release-github| |npm-package|
 
 CARTA is the Cube Analysis and Rendering Tool for Astronomy. This document describes the installation and configuration process for a site deployment of CARTA, including the controller and its dependencies. We recommend this deployment option for organisations providing CARTA to multiple users.
 
 Detailed :ref:`step-by-step instructions <step_by_step>` are provided for a standalone CARTA deployment on a dedicated server. Please use these instructions as a starting point, and make adjustments as required to integrate CARTA into your organisation's existing systems. More detailed information about customisation can be found in the :ref:`installation` and :ref:`configuration` sections.
 
-We officially support Ubuntu 20.04 (v4.x only), 22.04, and 24.04 (v5.x only), and AlmaLinux 8 and 9 (and equivalent RPM-based distributions), with all available standard updates applied. We provide legacy support only for existing 4.x installations on RHEL 7 and equivalents.
+We officially support Ubuntu 22.04 and 24.04, and AlmaLinux 8 and 9 (and equivalent RPM-based distributions), with all available standard updates applied.
 
 .. toctree::
    :maxdepth: 2
@@ -25,13 +35,25 @@ We officially support Ubuntu 20.04 (v4.x only), 22.04, and 24.04 (v5.x only), an
    schema
    schema_backend
 
-.. |backend-github| image:: https://img.shields.io/badge/CARTA%20Version-5.0.0--dev-brightgreen
-        :alt: View this backend version on GitHub
-        :target: https://github.com/CARTAvis/carta-backend/tree/dev
+.. |carta-release-github| image:: https://img.shields.io/badge/CARTA%20release-RELEASE-brightgreen
+        :alt: CARTA version
+        :target: https://github.com/CARTAvis/carta/releases/tag/vRELEASE
 
-.. |npm-package| image:: https://img.shields.io/npm/v/carta-controller/dev?style=flat
-        :alt: View this project on npm
-        :target: https://www.npmjs.com/package/carta-controller/v/5.0.0-beta.1
+.. |npm-package| image:: https://img.shields.io/npm/v/carta-controller?style=flat
+        :alt: NPM package
+        :target: https://www.npmjs.com/package/carta-controller/v/RELEASE
+
+.. |backend-github| image:: https://img.shields.io/badge/backend%20version-6.0.0--dev-brightgreen
+        :alt: CARTA backend version
+        :target: https://github.com/CARTAvis/carta-backend/
+
+.. |frontend-github| image:: https://img.shields.io/badge/frontend%20version-6.0.0--dev-brightgreen
+        :alt: CARTA frontend version
+        :target: https://github.com/CARTAvis/carta-frontend/
+
+.. |controller-github| image:: https://img.shields.io/badge/controller%20version-6.0.0--dev-brightgreen
+        :alt: CARTA controller version
+        :target: https://github.com/CARTAvis/carta-controller/
 
 .. |last-commit| image:: https://img.shields.io/github/last-commit/CARTAvis/carta-controller
         :alt: Last commit

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -41,7 +41,7 @@ We officially support Ubuntu 22.04 and 24.04, and AlmaLinux 8 and 9 (and equival
 
 .. |npm-package| image:: https://img.shields.io/npm/v/carta-controller/latest?style=flat
         :alt: NPM package
-        :target: https://www.npmjs.com/package/carta-controller/v/5.0.0
+        :target: https://www.npmjs.com/package/carta-controller/v/latest
 
 .. |backend-github| image:: https://img.shields.io/badge/backend%20version-6.0.0--dev-brightgreen
         :alt: CARTA backend version

--- a/docs/src/step_by_step.rst
+++ b/docs/src/step_by_step.rst
@@ -18,17 +18,13 @@ Overview
 
         .. note::
 
-            CARTA version 4.x is supported on Ubuntu 20.04 (Focal Fossa) and 22.04 (Jammy Jellyfish). CARTA version 5.x is supported on Ubuntu 22.04 (Jammy Jellyfish) and 24.04 (Noble Numbat).
-
-            The Ubuntu instructions can be used almost unchanged on Ubuntu 20.04 (Focal Fossa). We note differences where they occur. They should also work on equivalent Ubuntu-based distributions, and may work with some adjustments on other Debian-based distributions and non-LTS Ubuntu releases.
+            CARTA version 5.x is supported on Ubuntu 22.04 (Jammy Jellyfish) and 24.04 (Noble Numbat). The Ubuntu instructions should also work on equivalent Ubuntu-based distributions, and may work with some adjustments on other Debian-based distributions and non-LTS Ubuntu releases.
 
     .. tab:: AlmaLinux
 
         .. note::
 
-            CARTA versions 4.x and 5.x are both supported on AlmaLinux 8 and 9. The AlmaLinux instructions should also work on other equivalent RPM-based distributions.
-
-            We also support legacy installations of CARTA 4.x on RHEL 7 and CentOS 7, but as both of these releases have reached end of life and are widely unsupported, we do not recommend using them for new installations. Adapting these instructions to these releases requires multiple workarounds, which are outside the scope of this document.
+            CARTA version 5.x is supported on AlmaLinux 8 and 9. The AlmaLinux instructions should also work on other equivalent RPM-based distributions.
 
 .. _sbs_prerequisites:
 
@@ -70,10 +66,6 @@ Install MongoDB
     .. tab:: Ubuntu
 
         We recommend installing the `Community Edition Debian package of MongoDB <https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-ubuntu/>`_ on all supported Ubuntu versions.
-
-        .. note::
-
-            There is a ``mongodb`` package available from the official Ubuntu repositories on Ubuntu 20.04 (Focal Fossa). However, this package is older than the Community Edition package, and it has been discontinued in later LTS releases.
 
         .. code-block:: shell
 
@@ -160,7 +152,7 @@ Install CARTA backend and other required packages
 
         .. note::
 
-            Please note that Ubuntu packages for CARTA 4.x are only available for Focal and Jammy, and packages for CARTA 5.x are only available for Jammy and Noble.
+            Please note that Ubuntu packages for CARTA 5.x are only available for Jammy and Noble.
 
     .. tab:: AlmaLinux
 
@@ -208,7 +200,7 @@ Install CARTA backend and other required packages
 Install Node.js
 ~~~~~~~~~~~~~~~
 
-We recommend installing the `latest LTS version <https://github.com/nodejs/release#release-schedule>`_ of Node.js (currently v22) from the `NodeSource repository <https://github.com/nodesource/distributions>`_. The minimum version required for CARTA 5.x is v20. The oldest version known to work with CARTA 4.x is v16.
+We recommend installing the `latest LTS version <https://github.com/nodejs/release#release-schedule>`_ of Node.js (currently v22) from the `NodeSource repository <https://github.com/nodesource/distributions>`_. The minimum version required for CARTA 5.x is v20.
 
 .. tabs::
 


### PR DESCRIPTION
This is a parallel PR to #244, but for the release branch (simultaneous, to save time). The badges are configured for the release branch. Currently the NPM badge is pointing to the 4.1 controller; this will be fixed when the package gets the `latest` (and also `beta`) tag.

Once that has happened and these PRs are merged, I will tag this branch, change the tag on RTD, and remove the old beta version from RTD.