### PR TITLE
Get automated builds going

### DIFF
--- a/.github/build.yml
+++ b/.github/build.yml
@@ -2,8 +2,7 @@ name: Build Project
 
 on:
   push:
-    branches:
-      - aikema/github_build
+    branches: [ "aikema/github_build" ]
 
 jobs:
   build:

--- a/.github/build.yml
+++ b/.github/build.yml
@@ -1,0 +1,35 @@
+name: Build Project
+
+on:
+  push:
+    branches:
+      - aikema/github_build
+
+jobs:
+  build:
+    name: Node ${{ matrix.node }} build
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node: [20, 22, 24]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install libfoo dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++ make build-essential libpam0g-dev
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile TypeScript
+        run: npm run prepare

--- a/.github/build.yml
+++ b/.github/build.yml
@@ -2,8 +2,7 @@ name: Build Project
 
 on:
   push:
-    branches: [ "aikema/github_build" ]
-
+  
 jobs:
   build:
     name: Node ${{ matrix.node }} build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [20, 22, 24]
+        node: [22]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Compile TypeScript
         run: npm run prepare
+
+      - name: Run unit tests
+        run: npm run unit-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [20 22 24]
+        node: ['20', '22', '24']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install -y g++ make build-essential libpam0g-dev
 
       - name: Install dummy deps to avoid problems with carta-frontend's patch-package uses
-        run: npm install golden-layout react-split-pane --no-save
+        run: npm install golden-layout react-split-pane --no-save --ignore-scripts
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install -y g++ make build-essential libpam0g-dev
 
       - name: Install dummy deps to avoid problems with carta-frontend's patch-package uses
-        run: npm install golden-layout react-split-pane
+        run: npm install golden-layout react-split-pane --no-save
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install -y g++ make build-essential libpam0g-dev
 
       - name: Install dummy deps to avoid problems with carta-frontend's patch-package uses
-        run: npm install golden-layout react-split-pane --no-save --ignore-scripts
+        run: npm install golden-layout react-split-pane --ignore-scripts
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install -y g++ make build-essential libpam0g-dev
 
       - name: Install dummy deps to avoid problems with carta-frontend's patch-package uses
-        run: npm install golden-layout react-split-pane --no-save
+        run: npm install golden-layout react-split-pane
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,9 @@ name: Build Project
 on:
   push:
     branches:
-      - "**"
+      - dev
+      - release/*
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,9 @@ name: Build Project
 
 on:
   push:
-  
+    branches:
+      - "**"
+
 jobs:
   build:
     name: Node ${{ matrix.node }} build
@@ -21,7 +23,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Install libfoo dependency
+      - name: Install pam libs
         run: |
           sudo apt-get update
           sudo apt-get install -y g++ make build-essential libpam0g-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [22]
+        node: [20 22 24]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y g++ make build-essential libpam0g-dev
 
+      - name: Install dummy deps to avoid problems with carta-frontend's patch-package uses
+        run: npm install golden-layout react-split-pane --no-save
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y g++ make build-essential libpam0g-dev
 
-      - name: Install dummy deps to avoid problems with carta-frontend's patch-package uses
-        run: npm install golden-layout react-split-pane --ignore-scripts
-
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Compile TypeScript
         run: npm run prepare

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
                 "@types/cors": "^2.8.10",
                 "@types/express": "^4.17.11",
                 "@types/http-proxy": "^1.17.16",
-                "@types/jsonwebtoken": "^9.0.7",
+                "@types/jsonwebtoken": "9.0.6",
                 "@types/lodash": "^4.17.15",
                 "@types/ms": "^0.7.31",
                 "@types/node": "^22.13.1",
@@ -4759,9 +4759,9 @@
             "license": "MIT"
         },
         "node_modules/@types/jsonwebtoken": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.7.tgz",
-            "integrity": "sha512-ugo316mmTYBl2g81zDFnZ7cfxlut3o+/EQdaP7J8QN2kY6lJ22hmQYCK5EHcJHbrW+dkCGSCPgbG8JtYj6qSrg==",
+            "version": "9.0.6",
+            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
+            "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
                 "@types/uuid": "^9.0.0",
                 "@types/websocket": "^1.0.2",
                 "@types/yargs": "^17.0.22",
-                "patch-package": "^7.0.0",
                 "prettier": "2.8.4",
                 "ts-node": "^10.9.1",
                 "typescript": "^5.5.4",
@@ -15168,50 +15167,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
-        },
-        "node_modules/patch-package": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-7.0.2.tgz",
-            "integrity": "sha512-PMYfL8LXxGIRmxXLqlEaBxzKPu7/SdP13ld6GSfAUJUZRmBDPp8chZs0dpzaAFn9TSPnFiMwkC6PJt6pBiAl8Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@yarnpkg/lockfile": "^1.1.0",
-                "chalk": "^4.1.2",
-                "ci-info": "^3.7.0",
-                "cross-spawn": "^7.0.3",
-                "find-yarn-workspace-root": "^2.0.0",
-                "fs-extra": "^9.0.0",
-                "klaw-sync": "^6.0.0",
-                "minimist": "^1.2.6",
-                "open": "^7.4.2",
-                "rimraf": "^2.6.3",
-                "semver": "^7.5.3",
-                "slash": "^2.0.0",
-                "tmp": "^0.0.33",
-                "yaml": "^2.2.2"
-            },
-            "bin": {
-                "patch-package": "index.js"
-            },
-            "engines": {
-                "node": ">=14",
-                "npm": ">5"
-            }
-        },
-        "node_modules/patch-package/node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
         },
         "node_modules/path-exists": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/http-proxy": "^1.17.16",
-        "@types/jsonwebtoken": "^9.0.7",
+        "@types/jsonwebtoken": "9.0.6",
         "@types/lodash": "^4.17.15",
         "@types/ms": "^0.7.31",
         "@types/node": "^22.13.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
         "@types/uuid": "^9.0.0",
         "@types/websocket": "^1.0.2",
         "@types/yargs": "^17.0.22",
-        "patch-package": "^7.0.0",
         "prettier": "2.8.4",
         "ts-node": "^10.9.1",
         "typescript": "^5.5.4",


### PR DESCRIPTION
This attempts to get automated builds working via GitHub actions.

Note that `carta-frontend`'s use of `patch-package` was causing endless issues regarding its attempts to run patching due to looking in the controller's `node_modules` for packages only in the frontend.  This was worked around by adding `--ignore-scripts` to the `npm ci` command.  Following this we seem to be able least able to compile the typescript which I think gives us what we're looking for.  Not sure if `--ignore-scripts` might cause any issues if we'd not doing anything here beyond running an `npx tsc`.