### PR TITLE
Simplify badges. Remove obsolete note and warning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # CARTA Controller
-<!-- These badges should only be uncommented in release branches, and point to the appropriate tags: -->
-<!--[![CARTA version](https://img.shields.io/github/v/release/CartaVis/carta?label=CARTA%20release)](https://github.com/CARTAvis/carta/releases/latest)-->
-<!--[![npm package](https://img.shields.io/npm/v/carta-controller/latest?label=Controller%20release)](https://www.npmjs.com/package/carta-controller/v/latest)-->
-<!-- These badges should only be uncommented in dev, and updated with the dev version: -->
-[![CARTA backend version](https://img.shields.io/badge/backend%20branch-dev-brightgreen)](https://github.com/CARTAvis/carta-backend/)
-[![CARTA frontend version](https://img.shields.io/badge/frontend%20branch-dev-brightgreen)](https://github.com/CARTAvis/carta-frontend/)
+
+[![latest stable release](https://img.shields.io/npm/v/carta-controller/latest?label=stable%20release)](https://www.npmjs.com/package/carta-controller/v/latest)
+[![latest preview release](https://img.shields.io/npm/v/carta-controller/beta?label=preview%20release)](https://www.npmjs.com/package/carta-controller/v/beta)
 ![last commit](https://img.shields.io/github/last-commit/CARTAvis/carta-controller)
 ![commit activity](https://img.shields.io/github/commit-activity/m/CARTAvis/carta-controller)
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -6,19 +6,9 @@
 CARTA Controller
 ================
 
-..
-        These badges should be uncommented only in the dev branch.
-        Don't forget to update the dev version in the definitions below.
+|stable-release| |preview-release| |last-commit| |commit-activity|
 
-|backend-github| |frontend-github| |controller-github| |last-commit| |commit-activity|
-
-..
-        These badges should be uncommented only in release branches.
-        Don't forget to update the versions and tags in the definitions below.
-
-        |carta-release-github| |npm-package|
-
-CARTA is the Cube Analysis and Rendering Tool for Astronomy. This document describes the installation and configuration process for a site deployment of CARTA, including the controller and its dependencies. We recommend this deployment option for organisations providing CARTA to multiple users.
+`CARTA <https://cartavis.org/>`_ is the Cube Analysis and Rendering Tool for Astronomy. This document describes the installation and configuration process for a site deployment of CARTA, including the controller and its dependencies. We recommend this deployment option for organisations providing CARTA to multiple users.
 
 Detailed :ref:`step-by-step instructions <step_by_step>` are provided for a standalone CARTA deployment on a dedicated server. Please use these instructions as a starting point, and make adjustments as required to integrate CARTA into your organisation's existing systems. More detailed information about customisation can be found in the :ref:`installation` and :ref:`configuration` sections.
 
@@ -35,28 +25,16 @@ We officially support Ubuntu 22.04 and 24.04, and AlmaLinux 8 and 9 (and equival
    schema
    schema_backend
 
-.. |carta-release-github| image:: https://img.shields.io/github/v/release/CartaVis/carta?label=CARTA%20release
-        :alt: CARTA version
-        :target: https://github.com/CARTAvis/carta/releases/latest
-
-.. |npm-package| image:: https://img.shields.io/npm/v/carta-controller/latest?label=Controller%20release
-        :alt: NPM package
+.. |stable-release| image:: https://img.shields.io/npm/v/carta-controller/latest?label=stable%20release
+        :alt: Last stable NPM release
         :target: https://www.npmjs.com/package/carta-controller/v/latest
 
-.. |backend-github| image:: https://img.shields.io/badge/backend%20branch-dev-brightgreen
-        :alt: CARTA backend version
-        :target: https://github.com/CARTAvis/carta-backend/
-
-.. |frontend-github| image:: https://img.shields.io/badge/frontend%20branch-dev-brightgreen
-        :alt: CARTA frontend version
-        :target: https://github.com/CARTAvis/carta-frontend/
-
-.. |controller-github| image:: https://img.shields.io/badge/controller%20branch-dev-brightgreen
-        :alt: CARTA controller version
-        :target: https://github.com/CARTAvis/carta-controller/
+.. |preview-release| image:: https://img.shields.io/npm/v/carta-controller/beta?label=preview%20release
+        :alt: Last preview NPM release
+        :target: https://www.npmjs.com/package/carta-controller/v/beta
 
 .. |last-commit| image:: https://img.shields.io/github/last-commit/CARTAvis/carta-controller
-        :alt: Last commit
+        :alt: Last dev commit
 
 .. |commit-activity| image:: https://img.shields.io/github/commit-activity/m/CARTAvis/carta-controller
         :alt: Commit activity

--- a/docs/src/step_by_step.rst
+++ b/docs/src/step_by_step.rst
@@ -150,10 +150,6 @@ Install CARTA backend and other required packages
 
             Make sure that you install the matching controller version (using the ``beta`` tag).
 
-        .. note::
-
-            Please note that Ubuntu packages for CARTA 5.x are only available for Jammy and Noble.
-
     .. tab:: AlmaLinux
 
         RPM packages of the CARTA backend are available from our `Copr repository <https://copr.fedorainfracloud.org/coprs/cartavis/carta/>`_.
@@ -514,10 +510,6 @@ You should now be able to navigate to your domain, log into CARTA with your test
 .. note::
 
     In the example above, the default test image packaged with the CARTA backend is copied into the test user's home directory -- if you configured a different user directory structure, or installed a custom backend, please adjust these paths.
-
-.. warning::
-
-    A known issue in the CARTA v5 beta release prevents the packaged test image from rendering correctly. Please use a different image to test this version of CARTA. Example FITS images can be downloaded from various astronomical `institutions <https://fits.gsfc.nasa.gov/fits_samples.html>`_ and `software projects <https://www.astropy.org/astropy-data/>`_.
 
 .. _sbs_config_autostart:
 


### PR DESCRIPTION
This is a post-release docs cleanup PR.

* I'm undoing my own complicated badges change. The badges should be used to show the status of the project, not to connect individual release versions to CARTA versions. Maintaining different badges in dev and the release branch never works. I have now simplified this to showing the last stable release of the controller on NPM, the last preview ("beta" channel) release, the last commit, and the commit activity. I intend to backport this to the release branch, so that it's the same in all versions of the docs.
* I've removed two obsolete notes that I missed previously.