### PR TITLE
Improve handling of preferences DB ops

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -140,7 +140,7 @@ async function handleSetPreferences(req: AuthenticatedRequest, res: Response, ne
             logger.debug("Preferences updated");
             res.json({success: true});
         } else {
-            logger.warning("Error updateing preferences");
+            logger.warning("Error updating preferences");
             return next({statusCode: 500, message: "Problem updating preferences"});
         }
     } catch (err) {

--- a/src/database.ts
+++ b/src/database.ts
@@ -15,7 +15,7 @@ const preferenceSchema = require("../schemas/preferences_schema_2.json");
 const layoutSchema = require("../schemas/layout_schema_2.json");
 const snippetSchema = require("../schemas/snippet_schema_1.json");
 const workspaceSchema = require("../schemas/workspace_schema_1.json");
-const ajv = new Ajv({useDefaults: true, strictTypes: false});
+const ajv = new Ajv({useDefaults: false, strictTypes: false});
 addFormats(ajv);
 const validatePreferences = ajv.compile(preferenceSchema);
 const validateLayout = ajv.compile(layoutSchema);
@@ -121,6 +121,7 @@ async function handleSetPreferences(req: AuthenticatedRequest, res: Response, ne
     const update = req.body;
     // Check for malformed update
     if (!update || !Object.keys(update).length || update.username || update._id) {
+        logger.warning("Malformed preference update received");
         return next({statusCode: 400, message: "Malformed preference update"});
     }
 
@@ -136,8 +137,10 @@ async function handleSetPreferences(req: AuthenticatedRequest, res: Response, ne
     try {
         const updateResult = await preferenceCollection.updateOne({username: req.username}, {$set: update}, {upsert: true});
         if (updateResult.acknowledged) {
+            logger.debug("Preferences updated");
             res.json({success: true});
         } else {
+            logger.warning("Error updateing preferences");
             return next({statusCode: 500, message: "Problem updating preferences"});
         }
     } catch (err) {
@@ -158,6 +161,7 @@ async function handleClearPreferences(req: AuthenticatedRequest, res: Response, 
     const keys: string[] = req.body?.keys;
     // Check for malformed update
     if (!keys || !Array.isArray(keys) || !keys.length) {
+        logger.debug("Malformed key list received for clearing preferences");
         return next({statusCode: 400, message: "Malformed key list"});
     }
 
@@ -169,11 +173,14 @@ async function handleClearPreferences(req: AuthenticatedRequest, res: Response, 
     try {
         const updateResult = await preferenceCollection.updateOne({username: req.username}, {$unset: update});
         if (updateResult.acknowledged) {
+            logger.debug("Preferences cleared");
             res.json({success: true});
         } else {
+            logger.debug("Error clearing preferences");
             return next({statusCode: 500, message: "Problem clearing preferences"});
         }
     } catch (err) {
+        logger.debug("Error clearing preferences");
         logger.debug(err);
         return next({statusCode: 500, message: "Problem clearing preferences"});
     }

--- a/src/database.ts
+++ b/src/database.ts
@@ -100,10 +100,8 @@ async function handleGetPreferences(req: AuthenticatedRequest, res: Response, ne
             }
             res.json({success: true, preferences: doc});
         } else {
-            return next({
-                statusCode: 500,
-                message: "Problem retrieving preferences"
-            });
+            logger.debug(`No preferences found for user ${req.username}`);
+            res.json({success: true, preferences: {}});
         }
     } catch (err) {
         logger.debug(err);

--- a/src/database.ts
+++ b/src/database.ts
@@ -16,11 +16,13 @@ const layoutSchema = require("../schemas/layout_schema_2.json");
 const snippetSchema = require("../schemas/snippet_schema_1.json");
 const workspaceSchema = require("../schemas/workspace_schema_1.json");
 const ajv = new Ajv({useDefaults: false, strictTypes: false});
+const ajvWithDefaults = new Ajv({useDefaults: true, strictTypes: false});
 addFormats(ajv);
+addFormats(ajvWithDefaults);
 const validatePreferences = ajv.compile(preferenceSchema);
-const validateLayout = ajv.compile(layoutSchema);
-const validateSnippet = ajv.compile(snippetSchema);
-const validateWorkspace = ajv.compile(workspaceSchema);
+const validateLayout = ajvWithDefaults.compile(layoutSchema);
+const validateSnippet = ajvWithDefaults.compile(snippetSchema);
+const validateWorkspace = ajvWithDefaults.compile(workspaceSchema);
 
 let client: MongoClient;
 let preferenceCollection: Collection;


### PR DESCRIPTION
Tackles #258 (though this needs to be fixed in the release branch before that should be closed).

Have left in some additional `logger` statements in case needed to detect future errors, but debug-level won't be output at the default log level.

A later addition following discussions with @confluence is returning an empty set of preferences if none are found in the database.